### PR TITLE
Fixes for libraries in simulation.

### DIFF
--- a/src/ipbb/depparser/ModelSimProjectMaker.py
+++ b/src/ipbb/depparser/ModelSimProjectMaker.py
@@ -37,10 +37,11 @@ class ModelSimProjectMaker(object):
         for setup in (c for c in aCommandList['setup'] if not c.Finalise):
             write('source {0}'.format(setup.FilePath))
 
-        write('vlib work')
+        write('vlib xil_defaultlib')
 
         for lib in set(aLibs):
             write('vlib {0}'.format(lib))
+            write('vmap {} {}'.format(lib, lib))
 
         lSrcs = aCommandList['src'] if not self.reverse else reversed(aCommandList['src'])
 
@@ -108,6 +109,8 @@ class ModelSimProjectMaker(object):
 
                 if src.Lib:
                     cmd = '{0} -work {1}'.format(cmd, src.Lib)
+                else:
+                    cmd = '{0} -work xil_defaultlib'.format(cmd)
                 # ----------------------------------------------------------
 
             if self.turbo:


### PR DESCRIPTION
The default simulation library for src files was `work`. A VHDL `use work.xyz` statement resolves to component/package `xyz` in the library of the file containing the statement. If this source file is compiled into a library other than `work`, it is not possible to refer to it. Xilinx uses `xil_defaultlib` for the default library, so I have made this the default library for simulations created with ipbb. Use statements like `use xil_defaultlib.xyz` are then safe for both simulation and synthesis (at least with Vivado).

Related:
https://insights.sigasi.com/tech/work-not-vhdl-library/
https://forums.xilinx.com/t5/Design-Entry/xil-defaultlib/td-p/819042