### PR TITLE
Possibility to add .mem files to Vivado project

### DIFF
--- a/src/ipbb/depparser/VivadoProjectMaker.py
+++ b/src/ipbb/depparser/VivadoProjectMaker.py
@@ -29,7 +29,8 @@ class VivadoProjectMaker(object):
         '.xci': 'sources_1',
         '.ngc': 'sources_1',
         '.edn': 'sources_1',
-        '.edf': 'sources_1'
+        '.edf': 'sources_1',
+        '.mem': 'sources_1'
         # Legacy ISE files
         # '.ucf': 'ise_1',
         # '.xco': 'ise_1',


### PR DESCRIPTION
Hi,

I'm using XPM memories[1] in my design and these can be initialised using mem files[2]. It seems that Vivado wants those added to the project before they can be used, so I've added them in the list of files ipbb understands.

[1] https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_1/ug974-vivado-ultrascale-libraries.pdf (pages 76 and following)
[2] https://www.xilinx.com/support/documentation/sw_manuals/xilinx2019_1/ug898-vivado-embedded-design.pdf#page=164
