### PR TITLE
Feature: basic bin file support for Vivado package stage

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -427,13 +427,13 @@ def binfile(env):
     if not exists(lBitPath):
         raise click.ClickException("Bitfile does not exist. Can't create binfile.")
 
-    lBinFileCmdBase = lDepFileParser.vars['prom_file_cmd']
+    lBinFileCmdOptions = lDepFileParser.vars['vivado_binfile_options']
 
     ensureVivado(env)
 
     lOpenCmds = ['open_project %s' % env.vivadoProjFile]
 
-    lBinFileCmd  = '%s -loadbit {up 0x00000000 "%s" } -file "%s"' % (lBinFileCmdBase, lBitPath, lBinPath)
+    lBinFileCmd  = 'write_cfgmem -format bin %s -loadbit {up 0x00000000 "%s" } -file "%s"' % (lBinFileCmdOptions, lBitPath, lBinPath)
     lBinFileCmds = [lBinFileCmd]
 
     try:

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -595,7 +595,7 @@ def package(env, aTag):
         bitfile(env)
 
     wantBinFile = False
-    if env.depParser.vars.has_key('prom_file_cmd'):
+    if env.depParser.vars.has_key('vivado_binfile_options'):
         wantBinFile = True
     if wantBinFile:
         lBinPath = lBitPath.replace('.bit', '.bin')


### PR DESCRIPTION
First step basic support for creation of .bin files in addition to .bit files in the 'ipbb vivado package' step.

This implementation checks for the presence of a variable 'prom_file_cmd' in the ipbb project, and if present uses that command to generate a .bin file with the contents of the .bit file at address 0x0. This should cover at least all simple use cases.

Example prom_file_cmd: `@prom_file_cmd = "write_cfgmem -format bin -size 128 -interface BPIx16"`.