### PR TITLE
Factorise Vivado console interface code

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -28,7 +28,7 @@ done
 #--------------------------
 
 # Locale settings
-locale -a | grep -e "^\(C\|en_US\)"
+# locale -a | grep -e "^\(C\|en_US\)"
 if [[ "${PYTHON_MAJOR}" == "3" ]]; then
     echo -e "${COL_GREEN}Python 3 detected${COL_NULL}"
     # export IPBB_LANG=C.utf8

--- a/src/ipbb/cli/vivado.py
+++ b/src/ipbb/cli/vivado.py
@@ -68,6 +68,14 @@ def makeproject(env, aEnableIPCache, aOptimise, aToScript, aToStdout):
 
 
 # ------------------------------------------------------------------------------
+@vivado.command('list-project', short_help='List files in the project.')
+@click.pass_obj
+def listproject(env):
+    from ..cmds.vivado import listproject
+    listproject(env)
+
+
+# ------------------------------------------------------------------------------
 @vivado.command('check-syntax', short_help='Run the synthesis step on the current project.')
 @click.pass_obj
 def checksyntax(env):

--- a/src/ipbb/cli/vivado.py
+++ b/src/ipbb/cli/vivado.py
@@ -66,15 +66,6 @@ def makeproject(env, aEnableIPCache, aOptimise, aToScript, aToStdout):
     from ..cmds.vivado import makeproject
     makeproject(env, aEnableIPCache, aOptimise, aToScript, aToStdout)
 
-
-# ------------------------------------------------------------------------------
-@vivado.command('list-project', short_help='List files in the project.')
-@click.pass_obj
-def listproject(env):
-    from ..cmds.vivado import listproject
-    listproject(env)
-
-
 # ------------------------------------------------------------------------------
 @vivado.command('check-syntax', short_help='Run the synthesis step on the current project.')
 @click.pass_obj

--- a/src/ipbb/cmds/formatters.py
+++ b/src/ipbb/cmds/formatters.py
@@ -30,9 +30,15 @@ class DepFormatter(object):
         return ' '.join(list(aPkgs))
 
     def drawPackages(self):
+        """
+        Draws the list of packages
+        """
         return self._drawPackages(self.parser.packages)
 
     def drawUnresolvedPackages(self):
+        """
+        Draws the list of unresolved packages
+        """
         return self._drawPackages(self.parser.unresolvedPackages)
 
     def _drawComponents(self, aPkgs):
@@ -50,12 +56,21 @@ class DepFormatter(object):
         return lString[:-1]
 
     def drawComponents(self):
+        """
+        Draws the component tree
+        """
         return self._drawComponents(self.parser.packages)
 
     def drawUnresolvedComponents(self):
+        """
+        Draws the unresolved component tree
+        """
         return self._drawComponents(self.parser.unresolvedComponents)
 
     def drawUnresolvedFiles(self):
+        """
+        Draws the table of unresolved files
+        """
         lFNF = self.parser.unresolvedFiles
         if not lFNF:
             return ""

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -502,10 +502,6 @@ def status(env):
 
     lSessionId = 'status'
 
-    # if env.currentproj.name is None:
-    #     raise click.ClickException(
-    #         'Project area not defined. Move into a project area and try again')
-
     ensureVivado(env)
 
     lOpenCmds = ['open_project %s' % env.vivadoProjFile]

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -124,41 +124,6 @@ def makeproject(env, aEnableIPCache, aOptimise, aToScript, aToStdout):
 
 
 # ------------------------------------------------------------------------------
-def listproject(env):
-
-    lSessionId = 'list'
-
-    # Check
-    lVivProjPath = env.vivadoProjFile
-    if not exists(lVivProjPath):
-        raise click.ClickException("Vivado project %s does not exist" % lVivProjPath)
-
-    ensureVivado(env)
-
-    try:
-        with VivadoOpen(lSessionId, echo=env.vivadoEcho) as lConsole:
-            # Open the project
-            lConsole('open_project {}'.format(lVivProjPath))
-            lFileSets = lConsole('get_filesets')[0].split()
-            print(lFileSets)
-            lSources = lConsole('get_files -of [get_fileset sources_1]')[0].split()
-            lConstrs = lConsole('get_files -of [get_fileset constrs_1]')[0].split()
-            lUtils = lConsole('get_files -of [get_fileset utils_1]')[0].split()
-            lIPs = lConsole('get_ips')[0]
-            print(lIPs)
-            lXcis = []
-            for ip in lIPs.split():
-                lXcis += lConsole('get_property IMPORTED_FROM [get_files -of [get_filesets {0}] {0}.xci]'.format(ip))
-            print(lXcis)
-
-
-
-
-    except VivadoConsoleError as lExc:
-        echoVivadoConsoleError(lExc)
-        raise click.Abort()
-
-# ------------------------------------------------------------------------------
 def checksyntax(env):
 
     lSessionId = 'chk-syn'

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -520,8 +520,8 @@ def status(env):
     lRunRegex = re.compile(r'(synth|impl)_\d+')
 
     try:
-        with VivadoOpen(lSessionId, echo=env.vivadoEcho) as lConsole:
-            echo('Opening project')
+        with VivadoOpen(lSessionId, echo=env.vivadoEcho, echobanner=False) as lConsole:
+            echo('Opening project ' + env.currentproj.name)
 
             with VivadoSnoozer(lConsole):
                 lConsole(lOpenCmds)

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -124,6 +124,41 @@ def makeproject(env, aEnableIPCache, aOptimise, aToScript, aToStdout):
 
 
 # ------------------------------------------------------------------------------
+def listproject(env):
+
+    lSessionId = 'list'
+
+    # Check
+    lVivProjPath = env.vivadoProjFile
+    if not exists(lVivProjPath):
+        raise click.ClickException("Vivado project %s does not exist" % lVivProjPath)
+
+    ensureVivado(env)
+
+    try:
+        with VivadoOpen(lSessionId, echo=env.vivadoEcho) as lConsole:
+            # Open the project
+            lConsole('open_project {}'.format(lVivProjPath))
+            lFileSets = lConsole('get_filesets')[0].split()
+            print(lFileSets)
+            lSources = lConsole('get_files -of [get_fileset sources_1]')[0].split()
+            lConstrs = lConsole('get_files -of [get_fileset constrs_1]')[0].split()
+            lUtils = lConsole('get_files -of [get_fileset utils_1]')[0].split()
+            lIPs = lConsole('get_ips')[0]
+            print(lIPs)
+            lXcis = []
+            for ip in lIPs.split():
+                lXcis += lConsole('get_property IMPORTED_FROM [get_files -of [get_filesets {0}] {0}.xci]'.format(ip))
+            print(lXcis)
+
+
+
+
+    except VivadoConsoleError as lExc:
+        echoVivadoConsoleError(lExc)
+        raise click.Abort()
+
+# ------------------------------------------------------------------------------
 def checksyntax(env):
 
     lSessionId = 'chk-syn'
@@ -567,8 +602,6 @@ def reset(env):
         "\n{}: synth_1 and impl_1 successfully reset.\n".format(env.currentproj.name),
         fg='green',
     )
-
-
 # ------------------------------------------------------------------------------
 
 

--- a/src/ipbb/depparser/DepParser.py
+++ b/src/ipbb/depparser/DepParser.py
@@ -47,7 +47,6 @@ class FileCommand(Command):
         Package   (str):  package the target belongs to.
         Component (str):  component withon 'Package' the target belongs to
         Lib       (str):  library the file will be added to
-        Include   (bool): src-only flag, used to include/exclude target from projects
         TopLevel  (bool): addrtab-only flag, identifies address table as top-level
         Vhdl2008  (bool): src-only flag, toggles the vhdl 2008 syntax for .vhd files
         Finalise  (bool): setup-only flag, identifies setup scripts to be executed at the end
@@ -58,7 +57,6 @@ class FileCommand(Command):
         super(FileCommand, self).__init__(aCmd, aFilePath, aPackage, aComponent)
 
         self.Lib = aLib
-        self.Include = aInclude
         self.TopLevel = aTopLevel
         self.Vhdl2008 = aVhdl2008
         self.Finalise = aFinalise
@@ -74,8 +72,6 @@ class FileCommand(Command):
     # --------------------------------------------------------------
     def flags(self):
         lFlags = []
-        if not self.Include:
-            lFlags.append('noinclude')
         if self.TopLevel:
             lFlags.append('top')
         if self.Vhdl2008:
@@ -195,6 +191,7 @@ class DepCmdParser(argparse.ArgumentParser):
         subp.add_argument('file', nargs='*')
         subp.add_argument('-f', '--finalise', action='store_true')
 
+        # Utilites sub-parser
         subp = parser_add.add_parser('util')
         subp.add_argument('-c', '--component', **lCompArgOpts)
         subp.add_argument('--cd')
@@ -204,9 +201,6 @@ class DepCmdParser(argparse.ArgumentParser):
         subp = parser_add.add_parser('src')
         subp.add_argument('-c', '--component', **lCompArgOpts)
         subp.add_argument('-l', '--lib')
-        # subp.add_argument('-g', '--generated' , action = 'store_true') #
-        # TODO: Check if still used in Vivado
-        subp.add_argument('-n', '--noinclude', action='store_true')
         subp.add_argument('--cd')
         subp.add_argument('file', nargs='+')
         subp.add_argument('--vhdl2008', action='store_true')
@@ -216,7 +210,6 @@ class DepCmdParser(argparse.ArgumentParser):
         subp.add_argument('-c', '--component', **lCompArgOpts)
         subp.add_argument('--cd')
         subp.add_argument('-t', '--toplevel', action='store_true')
-        # subp.add_argument('-g', '--gendecoders', action='store_true')
         subp.add_argument('file', nargs='*')
 
         # Ip repository sub-parser
@@ -528,7 +521,6 @@ class DepFileParser(object):
                     lEntries.append(IncludeCommand(aParsedLine.cmd, lFilePath, lPackage, lComponent, self._parseFile(lPackage, lComponent, lFile)))
         else:
             # --------------------------------------------------------------
-            lInclude = ('noinclude' not in aParsedLine) or (not aParsedLine.noinclude)
             lTopLevel = ('toplevel' in aParsedLine and aParsedLine.toplevel)
             lFinalise = ('finalise' in aParsedLine and aParsedLine.finalise)
 
@@ -549,7 +541,7 @@ class DepFileParser(object):
                               aParsedLine.cmd, lFile, lFilePath)
                     # --------------------------------------------------------------
 
-                    lEntries.append(FileCommand(aParsedLine.cmd, lFilePath, lPackage, lComponent, lLib, lInclude, lTopLevel, lVhdl2008, lFinalise))
+                    lEntries.append(FileCommand(aParsedLine.cmd, lFilePath, lPackage, lComponent, lLib, lTopLevel, lVhdl2008, lFinalise))
 
         return lEntries
         # --------------------------------------------------------------

--- a/src/ipbb/depparser/DepParser.py
+++ b/src/ipbb/depparser/DepParser.py
@@ -163,6 +163,23 @@ class ComponentAction(argparse.Action):
 class DepCmdParserError(Exception):
     pass
 
+# -----------------------------------------------------------------------------
+class SrcTypeAction(argparse.Action):
+    def __init__(self, *args, **kwargs):
+        super(SrcTypeAction, self).__init__(*args, **kwargs)
+        self._choices = ['synth', 'sim']
+        self.default = self._choices
+
+    def __call__(self, parser, namespace, values, option_string=None):
+
+        tokens = values.split(',')
+        
+        lInvalid = [t for t in tokens if t not in self._choices]
+        if lInvalid:
+            raise ValueError('Invalid source types '+','.join(lInvalid))
+
+        setattr(namespace, self.dest, tokens )
+
 
 # -----------------------------------------------------------------------------
 class DepCmdParser(argparse.ArgumentParser):
@@ -204,6 +221,7 @@ class DepCmdParser(argparse.ArgumentParser):
         subp.add_argument('--cd')
         subp.add_argument('file', nargs='+')
         subp.add_argument('--vhdl2008', action='store_true')
+        subp.add_argument('-t', '--tyoe', action=SrcTypeAction)
 
         # Address table sub-parser
         subp = parser_add.add_parser('addrtab')

--- a/src/ipbb/depparser/ModelSimProjectMaker.py
+++ b/src/ipbb/depparser/ModelSimProjectMaker.py
@@ -40,6 +40,7 @@ class ModelSimProjectMaker(object):
 
         for lib in set(aLibs):
             write('vlib {0}'.format(lib))
+            write('vmap {0} {0}'.format(lib, lib))
 
         lSrcs = aCommandList['src']
 

--- a/src/ipbb/tools/xilinx.py
+++ b/src/ipbb/tools/xilinx.py
@@ -283,15 +283,15 @@ class VivadoConsole(object):
     # --------------------------------------------------------------
 
     # --------------------------------------------------------------
-    def __init__(self, sessionid=None, echo=True, echoprefix=None, executable='vivado', prompt=None, stopOnCWarnings=False):
+    def __init__(self, sessionid=None, echo=True, echobanner=True, echoprefix=None, executable='vivado', prompt=None, stopOnCWarnings=False):
         """
         Args:
             sessionid (str): Name of the Vivado session
-            echo (bool):
-            echoprefix (str):
-            executable (str):
+            echo (bool): Switch to enable echo messages
+            echoprefix (str): Prefix to echo message
+            executable (str): Executable name
             prompt (str):
-            stopOnCWarnings (str):
+            stopOnCWarnings (bool): Stop on Critical Warnings
         """
         super(VivadoConsole, self).__init__()
 
@@ -319,13 +319,18 @@ class VivadoConsole(object):
             quiet=(not echo)
         )
 
+        self._out.quiet = (not echobanner)
         self._out.write('\n' + '-' * 40 + '\n')
+       
         self._process = pexpect.spawnu('{0} -mode tcl -log {1}.log -journal {1}.jou'.format(
             self._executable,
             self._executable + ('_' + sessionid) if sessionid else ''),
             echo=echo,
             logfile=self._out
         )
+
+        self._out.quiet = (not echo)
+
 
         self._process.delaybeforesend = 0.00  # 1
 

--- a/src/ipbb/tools/xilinx/__init__.py
+++ b/src/ipbb/tools/xilinx/__init__.py
@@ -1,0 +1,4 @@
+from .vivado_console import *
+from .vivado_hwserver import *
+from .vivado_batch import *
+from .vivado_project import *

--- a/src/ipbb/tools/xilinx/vivado_batch.py
+++ b/src/ipbb/tools/xilinx/vivado_batch.py
@@ -1,0 +1,84 @@
+from __future__ import print_function, absolute_import
+from builtins import range
+import six
+# ------------------------------------------------------------------------------
+
+import re
+import sh
+
+# ------------------------------------------------------------------------------
+class VivadoBatch(object):
+    """
+    Wrapper class to run Vivado jobs in batch mode
+    """
+    _reInfo = re.compile(u'^INFO:')
+    _reWarn = re.compile(u'^WARNING:')
+    _reCritWarn = re.compile(u'^CRITICAL WARNING:')
+    _reError = re.compile(u'^ERROR:')
+
+    # --------------------------------------------
+    def __init__(self, scriptpath=None, echo=False, log=None, cwd=None, dryrun=False):
+        super(VivadoBatch, self).__init__()
+
+        if scriptpath:
+            _, lExt = splitext(scriptpath)
+            if lExt not in ['.tcl', '.do']:
+                raise ValueError('Unsupported extension {}. Use \'.tcl\' or \'.do\''.format(lExt))
+
+        self.scriptpath = scriptpath
+        self.log = log
+        self.terminal = sys.stdout if echo else None
+        self.cwd = cwd
+        self.dryrun = dryrun
+
+    # --------------------------------------------
+    def __enter__(self):
+        self.script = (
+            open(self.scriptpath, 'wt') if self.scriptpath
+            else tempfile.NamedTemporaryFile(mode='w+t', suffix='.do')
+        )
+        return self
+
+    # --------------------------------------------
+    def __exit__(self, type, value, traceback):
+        if not self.dryrun:
+            self._run()
+        self.script.close()
+
+    # --------------------------------------------
+    def __call__(self, *strings):
+        for f in [self.script, self.terminal]:
+            if not f:
+                continue
+            f.write(' '.join(strings) + '\n')
+            f.flush()
+
+    # --------------------------------------------
+    def _run(self):
+
+        # Define custom log file
+        lRoot, _ = splitext(basename(self.script.name))
+        lLog = 'vivado_{0}.log'.format(lRoot)
+        lJou = 'vivado_{0}.jou'.format(lRoot)
+
+        # Guard against missing vivado executable
+        if not which('vivado'):
+            raise VivadoNotFoundError(
+                '\'vivado\' not found in PATH. Have you sourced Vivado\'s setup script?'
+            )
+
+        sh.vivado('-mode', 'batch', '-source', self.script.name, '-log', lLog, '-journal', lJou, _out=sys.stdout, _err=sys.stderr)
+        self.errors = []
+        self.info = []
+        self.warnings = []
+
+        with open(lLog) as lLogFile:
+            for i, l in enumerate(lLogFile):
+                if self._reError.match(l):
+                    self.errors.append((i, l))
+                elif self._reWarn.match(l):
+                    self.warnings.append((i, l))
+                elif self._reInfo.match(l):
+                    self.info.append((i, l))
+    # --------------------------------------------
+# -------------------------------------------------------------------------

--- a/src/ipbb/tools/xilinx/vivado_console.py
+++ b/src/ipbb/tools/xilinx/vivado_console.py
@@ -64,30 +64,45 @@ class VivadoNotFoundError(Exception):
 
 
 # ------------------------------------------------
-def autodetect(executable='vivado'):
-    """
-Vivado v2017.4 (64-bit)
-SW Build 2086221 on Fri Dec 15 20:54:30 MST 2017
-IP Build 2085800 on Fri Dec 15 22:25:07 MST 2017
-Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.
-    """
+def _parseversion(verstr):
 
     lVerExpr = r'(Vivado[\s\w]*)\sv(\d+\.\d)'
 
     lVerRe = re.compile(lVerExpr, flags=re.IGNORECASE)
+
+    m = lVerRe.search(str(verstr))
+
+    if m is None:
+        raise VivadoNotFoundError("Failed to detect Vivado variant")
+
+    return m.groups()
+# ------------------------------------------------
+
+
+# ------------------------------------------------
+def autodetect(executable='vivado'):
+    """
+
+Vivado:
+    Vivado v2017.4 (64-bit)
+    SW Build 2086221 on Fri Dec 15 20:54:30 MST 2017
+    IP Build 2085800 on Fri Dec 15 22:25:07 MST 2017
+    Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.
+
+Vivado Lab:
+    Vivado Lab Edition v2017.4 (64-bit)
+    SW Build 2086221 on Fri Dec 15 20:54:30 MST 2017
+    Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.
+
+    """
+
 
     if not which(executable):
         raise VivadoNotFoundError("%s not found in PATH. Have you sourced Vivado\'s setup script?" % executable)
 
     lExe = sh.Command(executable)
     lVerStr = lExe('-version')
-
-    m = lVerRe.search(str(lVerStr))
-
-    if m is None:
-        raise VivadoNotFoundError("Failed to detect Vivado variant")
-
-    return m.groups()
+    return _parseversion(lVerStr)
 # ------------------------------------------------
 
 

--- a/src/ipbb/tools/xilinx/vivado_hls_console.py
+++ b/src/ipbb/tools/xilinx/vivado_hls_console.py
@@ -1,0 +1,4 @@
+from __future__ import print_function, absolute_import
+from builtins import range
+import six
+# ------------------------------------------------------------------------------

--- a/src/ipbb/tools/xilinx/vivado_hwserver.py
+++ b/src/ipbb/tools/xilinx/vivado_hwserver.py
@@ -1,0 +1,118 @@
+from __future__ import print_function, absolute_import
+from builtins import range
+import six
+# ------------------------------------------------------------------------------
+
+from .vivado_console import VivadoConsole
+
+# -------------------------------------------------------------------------
+class VivadoHWServer(VivadoConsole):
+
+    """Vivado Harware server object
+
+    Exposes a standard interface for programming devices.
+    """
+    
+    # --------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        super(VivadoHWServer, self).__init__(*args, **kwargs)
+
+    # --------------------------------------------------------------
+    def openHw(self):
+        return self.execute('open_hw')
+
+    # --------------------------------------------------------------
+    def connect(self, uri=None):
+        lCmd = ['connect_hw_server']
+        if uri is not None:
+            lCmd += ['-url ' + uri]
+        return self.execute(' '.join(lCmd))
+
+    # --------------------------------------------------------------
+    def getHwTargets(self):
+        return self.execute('get_hw_targets')[0].split()
+
+    # --------------------------------------------------------------
+    def openHwTarget(self, target, is_xvc=False):
+        return self.execute('open_hw_target {1} {{{0}}}'.format(target, '-xvc_url' if is_xvc else ''))
+
+    # --------------------------------------------------------------
+    def closeHwTarget(self, target=None):
+        lCmd = 'close_hw_target' + ('' if target is None else ' ' + target)
+        return self.execute(lCmd)
+
+    # --------------------------------------------------------------
+    def getHwDevices(self):
+        return self.execute('get_hw_devices')[0].split()
+
+    # --------------------------------------------------------------
+    def programDevice(self, device, bitfile, probe=None):
+        from os.path import abspath, normpath
+
+        bitpath = abspath(normpath(bitfile))
+
+        self._log.debug('Programming %s with %s', device, bitfile)
+
+        self.execute('current_hw_device {0}'.format(device))
+        self.execute(
+            'refresh_hw_device -update_hw_probes {} [current_hw_device]'.format("True" if probe else 'False')
+        )
+        self.execute(
+            'set_property PROBES.FILE {{{0}}} [current_hw_device]'.format(probe if probe else '')
+        )
+        self.execute(
+            'set_property PROGRAM.FILE {{{0}}} [current_hw_device]'.format(bitpath)
+        )
+        self.execute('program_hw_devices [current_hw_device]')
+
+
+# -------------------------------------------------------------------------
+class VivadoOpen(object):
+    """VivadoConsole wrapper for with statements
+    """
+
+    # --------------------------------------------------------------
+    def __getattr__(self, name):
+        if name.startswith('_'):
+            # bail out early
+            raise AttributeError(name)
+        return getattr(self._console, name)
+
+    # --------------------------------------------------------------
+    def __setattr__(self, name, value):
+        if name.startswith('_'):
+            self.__dict__[name] = value
+            return
+        return setattr(self._console, name, value)
+
+    # --------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        super(VivadoOpen, self).__init__()
+        self._args = args
+        self._kwargs = kwargs
+
+    # --------------------------------------------------------------
+    def __enter__(self):
+        self._console = VivadoConsole(*self._args, **self._kwargs)
+        return self
+
+    # --------------------------------------------------------------
+    def __exit__(self, type, value, traceback):
+        self._console.quit()
+
+    # --------------------------------------------------------------
+    def __call__(self, aCmd=None, aMaxLen=1):
+        # FIXME: only needed because of VivadoProjectMaker
+        # Fix at source and remove
+        if aCmd is None:
+            return
+
+        if aCmd.count('\n') is not 0:
+            aCmd = aCmd.split('\n')
+
+        if isinstance(aCmd, str):
+            return self._console.execute(aCmd, aMaxLen)
+        elif isinstance(aCmd, list):
+            return self._console.executeMany(aCmd, aMaxLen)
+        else:
+            raise TypeError('Unsupported command type ' + type(aCmd).__name__)

--- a/src/ipbb/tools/xilinx/vivado_project.py
+++ b/src/ipbb/tools/xilinx/vivado_project.py
@@ -1,0 +1,50 @@
+from __future__ import print_function, absolute_import
+from builtins import range
+import six
+# ------------------------------------------------------------------------------
+
+from .vivado_console import VivadoConsole
+
+# ------------------------------------------------------------------------------
+class VivadoProject(object):
+    """docstring for VivadoProject"""
+    def __init__(self, console):
+        super(VivadoProject, self).__init__()
+        self.console = console
+
+    def current(self):
+        """Name of the current prokecy, if any"""
+        return self.console('current_project -quiet')[0]
+    
+    def open(self, aPath):
+
+        if self.current():
+            self.close()
+
+        self.console('open_project {}'.format(aPath))
+
+    def create(self):
+        pass
+
+    def close(self):
+        self.console('close_project')
+
+    def listfiles(self):
+        
+        lConsole = self.console
+        lFiles = {}
+        lFileSets = lConsole('get_filesets')[0].split()
+        for s in lFileSets:
+            x = lConsole('get_files -quiet -of [get_fileset {}]'.format(s))[0]
+            lFiles[s] = x.split() if x else None
+        # lSources = lConsole('get_files -of [get_fileset sources_1]')[0].split()
+        # lConstrs = lConsole('get_files -of [get_fileset constrs_1]')[0].split()
+        # lUtils = lConsole('get_files -of [get_fileset utils_1]')[0].split()
+        lIPs = lConsole('get_ips -quiet')[0]
+        # print(lIPs)
+        lXcis = []
+        for ip in lIPs.split():
+            lXcis += lConsole('get_property IMPORTED_FROM [get_files -of [get_filesets {0}] {0}.xci]'.format(ip))
+        
+        lFiles['ips'] = lXcis
+        return lFiles

--- a/tests/pytests/test_xilinx.py
+++ b/tests/pytests/test_xilinx.py
@@ -20,4 +20,19 @@ def check_vivado_env():
 
 
 def test_autodetect(check_vivado_env):
-    xilinx.autodetect()
+
+    # Vivado:
+    lVivadoVer='''
+Vivado v2017.4 (64-bit)
+SW Build 2086221 on Fri Dec 15 20:54:30 MST 2017
+IP Build 2085800 on Fri Dec 15 22:25:07 MST 2017
+Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.
+'''
+
+    lVivadoLabVer='''
+Vivado Lab Edition v2017.4 (64-bit)
+SW Build 2086221 on Fri Dec 15 20:54:30 MST 2017
+Copyright 1986-2017 Xilinx, Inc. All Rights Reserved.
+'''
+    assert xilinx.vivado_console._parseversion(lVivadoVer) == ('Vivado','2017.4')
+    assert xilinx.vivado_console._parseversion(lVivadoLabVer) == ('Vivado Lab Edition','2017.4')


### PR DESCRIPTION
This PR splits the `ipbb.xilinx.vivado` module, originally coded in a single file, into separate files to simplify code management and extension.
Also prepare the ground for the vivado HLS interface.