### PR TITLE
Explicitly delete the Vivado session/console in 'vivado package' to avoid confusing session output at end of run

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -655,6 +655,13 @@ def package(env, aTag):
     if not os.path.exists(lDebugProbesPath):
         lDebugProbesPath = None
 
+    # At this point all Vivado manipulations are done. So let's close
+    # the Vivado session. Otherwise it will be closed automatically at
+    # the end, but in that case it may look confusing because it
+    # identifies with the session id from the last Vivado action
+    # (which is likely to be 'bitfile' or 'memcfg').
+    del env.vivadoSessions
+
     lPkgPath = 'package'
     lPkgSrcPath = join(lPkgPath, 'src')
 


### PR DESCRIPTION
The `ipbb vivado package` command is a bit special in the sense that it may or may not call on Vivado. The `package` step itself does not use Vivado, however. This means that depending on which `ipbb` commands are run before the `package` step and on the status of the project, the final Vivado console messages will be identified with an arbitrary session id.

For example, looking at the tail of the output of the following commands:

```
$ ipbb vivado package
...
Package package/dth_p1v1_nodeemu_cmstcdslab2_cern_ch_200814_1456.tgz successfully created.
```

```
$ ipbb vivado memcfg package
...
Package package/dth_p1v1_nodeemu_cmstcdslab2_cern_ch_200814_1458.tgz successfully created.
memcfg | Vivado%        quit
memcfg | quit
memcfg | INFO: [Common 17-206] Exiting Vivado at Fri Aug 14 14:58:46 2020...
memcfg | - Terminating Vivado (pid 1419) -----------------------------------------
```

The latter can be confusing because the last lines of output refer to the previous command (`memcfg`) instead of the last step (`package`).

This pull request fixes the above issue by explicitly deleting the Vivado session once it is no longer needed, instead of waiting for automatic deletion at the end of the run.
