### PR TITLE
Fix support for IP core containers

### DIFF
--- a/src/ipbb/makers/vivadoproject.py
+++ b/src/ipbb/makers/vivadoproject.py
@@ -21,7 +21,7 @@ class VivadoProjectMaker(object):
     filetypes = {
         'ip' : ('.xci', '.xcix'),
         'constr' : ('.xdc', '.tcl'),
-        'design' : ('.vhd', '.vhdl', '.v', '.sv', '.xci', '.ngc', '.edn', '.edf'),
+        'design' : ('.vhd', '.vhdl', '.v', '.sv', '.xci', '.xcix', '.ngc', '.edn', '.edf'),
     }
 
     @staticmethod
@@ -112,7 +112,7 @@ class VivadoProjectMaker(object):
             # local list of commands
             lCommands = []
 
-            if lExt == '.xci':
+            if lExt in ('.xci', '.xcix'):
 
                 c = 'import_files -norecurse -fileset {0} $files'.format(self.fileset(src))
                 f = src.filepath


### PR DESCRIPTION
It appears that when we introduced support for (.xcix) in PR #77, we
missed a few spots. This was noticeable because IP core containers did
not get upgraded when making new projects, but 'plain' IP cores were.

I believe that with this fix .xci and .xcix files are treated equally everywhere.