### PR TITLE
Fix/improve support for IP containers some more

### DIFF
--- a/src/ipbb/makers/vivadoproject.py
+++ b/src/ipbb/makers/vivadoproject.py
@@ -164,6 +164,8 @@ class VivadoProjectMaker(object):
         # for i in lXciTargetFiles:
             # write('create_ip_run [get_files {0}]'.format(i))
         for i in lXciBasenames:
+            write('delete_ip_run [get_ips {0}]'.format(i))
+            write('generate_target all [get_ips {0}]'.format(i))
             write('create_ip_run [get_ips {0}]'.format(i))
 
         for setup in (c for c in aCommandList['setup'] if c.finalize):


### PR DESCRIPTION
Further improvements as follow-up of PRs #77 and #85.

Since the .xcix file potentially carries a history of synthesis and/or
implementation runs, these runs need to be explicitly deleted before
creating any new ones. For good measure the targets should be
specified too.
See also: https://www.xilinx.com/support/answers/61144.html.