### PR TITLE
Add support for checking out a specific git revision by ID

### DIFF
--- a/src/ipbb/cli/repo.py
+++ b/src/ipbb/cli/repo.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import
 
 from ..cmds._utils import validateComponent
-from ._utils import completeSrcPackage
+from ._utils import completeSrcPackage, MutuallyExclusiveOption
 
 # Modules
 import click
@@ -39,14 +39,25 @@ def add(env):
 # ------------------------------------------------------------------------------
 @add.command('git', short_help="Add new source package from a git repository")
 @click.argument('repo')
-@click.option('-b', '--branch', default=None, help='Git branch or tag to clone')
+
+@click.option('-b',
+              '--branch',
+              default=None,
+              help='Git branch or tag to clone',
+              cls=MutuallyExclusiveOption,
+              mutually_exclusive=["revision"])
+@click.option('-r',
+              '--revision',
+              default=None,
+              help='Git revision ID to clone',
+              cls=MutuallyExclusiveOption,
+              mutually_exclusive=["branch"])
 @click.option('-d', '--dest', default=None, help="Destination directory")
-@click.option('-r', '--revision', default=None, help='Git revision ID to clone')
 @click.pass_obj
-def git(env, repo, branch, dest, revision):
+def git(env, repo, branch, revision, dest):
     '''Add a git repository to the source area'''
     from ..cmds.repo import git
-    git(env, repo, branch, dest, revision)
+    git(env, repo, branch, revision, dest)
 
 
 # ------------------------------------------------------------------------------

--- a/src/ipbb/cli/repo.py
+++ b/src/ipbb/cli/repo.py
@@ -41,11 +41,12 @@ def add(env):
 @click.argument('repo')
 @click.option('-b', '--branch', default=None, help='Git branch or tag to clone')
 @click.option('-d', '--dest', default=None, help="Destination directory")
+@click.option('-r', '--revision', default=None, help='Git revision ID to clone')
 @click.pass_obj
-def git(env, repo, branch, dest):
+def git(env, repo, branch, dest, revision):
     '''Add a git repository to the source area'''
     from ..cmds.repo import git
-    git(env, repo, branch, dest)
+    git(env, repo, branch, dest, revision)
 
 
 # ------------------------------------------------------------------------------

--- a/src/ipbb/cmds/repo.py
+++ b/src/ipbb/cmds/repo.py
@@ -216,7 +216,7 @@ def _repoReset(env, dest):
             sh.Command(cmd[0])(*cmd[1:], _out=sys.stdout)
 
 # ------------------------------------------------------------------------------
-def git(env, repo, branch, dest):
+def git(env, repo, branch, dest, revision):
     '''Add a git repository to the source area'''
 
     echo('Adding git repository ' + style(repo, fg='blue'))
@@ -284,6 +284,14 @@ def git(env, repo, branch, dest):
 
         echo('Checking out branch/tag ' + style(branch, fg='blue'))
         sh.git('checkout', branch, '-q', _out=sys.stdout, _cwd=lRepoLocalPath)
+
+    elif revision is not None:
+        echo('Checking out revision ' + style(revision, fg='blue'))
+        try:
+            sh.git('checkout', revision, '-q', _out=sys.stdout, _cwd=lRepoLocalPath)
+        except Exception as err:
+            secho("Failed to check out requested revision. Staying on master.", fg='red')
+            sh.git('checkout', 'master', '-q', _out=sys.stdout, _cwd=lRepoLocalPath)
 
     secho(
         'Repository \'{}\' successfully cloned to:\n  {}'.format(

--- a/src/ipbb/cmds/repo.py
+++ b/src/ipbb/cmds/repo.py
@@ -216,7 +216,7 @@ def _repoReset(env, dest):
             sh.Command(cmd[0])(*cmd[1:], _out=sys.stdout)
 
 # ------------------------------------------------------------------------------
-def git(env, repo, branch, dest, revision):
+def git(env, repo, branch, revision, dest):
     '''Add a git repository to the source area'''
 
     echo('Adding git repository ' + style(repo, fg='blue'))
@@ -280,6 +280,9 @@ def git(env, repo, branch, dest, revision):
 
     sh.git(*lArgs, _out=sys.stdout, _cwd=env.srcdir)
 
+    # NOTE: The mutual exclusivity of checking out a branch and
+    # checkout out a revision should have been handled at the CLI
+    # option handling stage.
     if branch is not None:
 
         echo('Checking out branch/tag ' + style(branch, fg='blue'))
@@ -290,8 +293,12 @@ def git(env, repo, branch, dest, revision):
         try:
             sh.git('checkout', revision, '-q', _out=sys.stdout, _cwd=lRepoLocalPath)
         except Exception as err:
-            secho("Failed to check out requested revision. Staying on master.", fg='red')
-            sh.git('checkout', 'master', '-q', _out=sys.stdout, _cwd=lRepoLocalPath)
+            # NOTE: The assumption here is that the failed checkout
+            # did not alter the state of the cloned repo in any
+            # way. (This appears to be the case from experience but no
+            # hard reference could be found.)
+            secho("Failed to check out requested revision." \
+                  " Staying on default branch.", fg='red')
 
     secho(
         'Repository \'{}\' successfully cloned to:\n  {}'.format(


### PR DESCRIPTION
Add the option 'ipbb add git ... -r XXX' to check out revision XXX
of the specified repo. (Because not all third-party repos always tag
whenever we want them to.) Both long and short revision hashes are
supported. Since the existence of the hash cannot be verified before-
hand (at least not without first cloning the repo) it is simply
assumed to exist. In case the checkout goes wrong, a message is
issued and the repo is reverted to the master branch.