### PR TITLE
Fix unicode strings for Vivado console prompt

### DIFF
--- a/src/ipbb/tools/xilinx/vivado_console.py
+++ b/src/ipbb/tools/xilinx/vivado_console.py
@@ -94,8 +94,8 @@ class VivadoConsole(object):
     __reCriticalWarning = re.compile(u'^CRITICAL WARNING:')
     __instances = set()
     __promptMap = {
-        'vivado': r'Vivado%\s',
-        'vivado_lab': r'vivado_lab%\s'
+        'vivado': u'Vivado%\s',
+        'vivado_lab': u'vivado_lab%\s'
     }
     __newlines = [u'\r\n']
 


### PR DESCRIPTION
I don't know how this problem snuck in. It looks as if the tests do already use a unicode string. Anyway...