### PR TITLE
Fixing UTF vs raw regex expressions for py2 and py3 in vivado_console 

### DIFF
--- a/src/ipbb/tools/xilinx/vivado_console.py
+++ b/src/ipbb/tools/xilinx/vivado_console.py
@@ -89,13 +89,13 @@ class VivadoConsole(object):
     
     """
 
-    __reCharBackspace = re.compile(u'.\x08')
-    __reError = re.compile(u'^ERROR:')
-    __reCriticalWarning = re.compile(u'^CRITICAL WARNING:')
+    __reCharBackspace = re.compile(r'.\x08')
+    __reError = re.compile(r'^ERROR:')
+    __reCriticalWarning = re.compile(r'^CRITICAL WARNING:')
     __instances = set()
     __promptMap = {
-        'vivado': r'Vivado%\s',
-        'vivado_lab': r'vivado_lab%\s'
+        'vivado': re.compile(r'Vivado%\s'),
+        'vivado_lab': re.compile(r'vivado_lab%\s')
     }
     __newlines = [u'\r\n']
 

--- a/src/ipbb/tools/xilinx/vivadohls_console.py
+++ b/src/ipbb/tools/xilinx/vivadohls_console.py
@@ -186,12 +186,12 @@ class VivadoHLSConsole(object):
     
     """
 
-    __reCharBackspace = re.compile(u'.\x08')
-    __reError = re.compile(u'^ERROR:')
-    __reCriticalWarning = re.compile(u'^CRITICAL WARNING:')
+    __reCharBackspace = re.compile(r'.\x08')
+    __reError = re.compile(r'^ERROR:')
+    __reCriticalWarning = re.compile(r'^CRITICAL WARNING:')
     __instances = set()
     __promptMap = {
-        'vivado_hls': r'\x1b\[2K\r\rvivado_hls>\s',
+        'vivado_hls': re.compile(r'\x1b\[2K\r\rvivado_hls>\s'),
     }
     __newlines = [u'\r\n']
     __cmdSentAck = '\r\x1b[12C\r'


### PR DESCRIPTION
Vivado console patterns converted in raw strings and wrapped in reges…
…, to keep pexpect and python happy.