### PR TITLE
Fix several Python3-related issues

### DIFF
--- a/src/ipbb/cmds/ipbus.py
+++ b/src/ipbb/cmds/ipbus.py
@@ -8,7 +8,7 @@ import click
 from click import echo, secho, style, confirm
 from os.path import join, split, exists, abspath, splitext, relpath, basename
 from ..defaults import kProjAreaFile, kProjUserFile
-from ..tools.common import which
+from ..tools.common import which, DEFAULT_ENCODING
 from ._utils import DirSentry, formatDictTable
 from .common import addrtab
 
@@ -97,7 +97,7 @@ def gendecoders(env, aCheckUpToDate, aForce):
             )
             for a in sorted(lErrors):
                 echo(' - ' + basename(a.filepath))
-                echo('   ' + lErrors[a].stdout)
+                echo('   ' + lErrors[a].stdout.decode(DEFAULT_ENCODING, "replace"))
             return
 
 

--- a/src/ipbb/cmds/sim.py
+++ b/src/ipbb/cmds/sim.py
@@ -17,6 +17,7 @@ import ipbb
 import ipbb.tools.xilinx as xilinx
 import ipbb.tools.mentor as mentor
 from ._utils import DirSentry, ensureNoParsingErrors, ensureNoMissingFiles, echoVivadoConsoleError
+from ..tools.common import DEFAULT_ENCODING
 
 # Elements
 from os.path import (
@@ -333,7 +334,7 @@ def ipcores(env, aXilSimLibsPath, aToScript, aToStdout):
     from configparser import RawConfigParser
 
     lIniParser = RawConfigParser()
-    lIniParser.read(lIPCoresModelsimIni, 'utf-8')
+    lIniParser.read(lIPCoresModelsimIni, DEFAULT_ENCODING)
     for lSimLib in lSimLibs:
         echo(' - ' + lSimLib)
         lIniParser.set('Library', lSimLib, join(lCoreSimDir, lSimLib))

--- a/src/ipbb/depparser/_cmdtypes.py
+++ b/src/ipbb/depparser/_cmdtypes.py
@@ -39,6 +39,10 @@ class Command(object):
         return (self.filepath == other.filepath)
 
     # --------------------------------------------------------------
+    def __lt__(self, other):
+        return (self.filepath < other.filepath)
+
+    # --------------------------------------------------------------
     def flags(self):
         return []
 
@@ -47,6 +51,7 @@ class Command(object):
         return None
 
     __repr__ = __str__
+    __hash__ = object.__hash__
 
 
 # -----------------------------------------------------------------------------
@@ -88,6 +93,7 @@ class SrcCommand(Command):
     def __eq__(self, other):
         return (self.filepath == other.filepath) and (self.lib == other.lib)
 
+    __hash__ = object.__hash__
 
 # -----------------------------------------------------------------------------
 class HlsSrcCommand(Command):

--- a/src/ipbb/tools/common.py
+++ b/src/ipbb/tools/common.py
@@ -8,6 +8,9 @@ import pexpect
 import subprocess
 import time
 
+from locale import getpreferredencoding
+
+DEFAULT_ENCODING = getpreferredencoding() or "UTF-8"
 
 # ------------------------------------------------------------------------------
 class SmartOpen(object):

--- a/src/ipbb/tools/mentor/sim_console.py
+++ b/src/ipbb/tools/mentor/sim_console.py
@@ -11,6 +11,7 @@ import logging
 
 from ..common import which
 from ..tcl_console import consolectxmanager, TCLConsoleSnoozer
+from ..common import DEFAULT_ENCODING
 from .sim_common import autodetect, ModelSimNotFoundError, ModelSimOutputFormatter, _vsim, _vcom
 
 # ------------------------------------------------------------------
@@ -98,6 +99,7 @@ class ModelSimConsole(object):
             env=lEnv,
             echo=echo,
             logfile=self._out,
+            encoding=DEFAULT_ENCODING,
         )
 
         self._process.delaybeforesend = 0.00  # 1

--- a/src/ipbb/tools/xilinx/vivado_console.py
+++ b/src/ipbb/tools/xilinx/vivado_console.py
@@ -23,7 +23,7 @@ from click import style
 from ..common import which
 # from ..termui import *
 from ..tcl_console import consolectxmanager, TCLConsoleSnoozer
-from ..tools.common import DEFAULT_ENCODING
+from ..common import DEFAULT_ENCODING
 from .vivado_common import VivadoNotFoundError, autodetect, VivadoOutputFormatter, _parseversion
 
 # ------------------------------------------------

--- a/src/ipbb/tools/xilinx/vivado_console.py
+++ b/src/ipbb/tools/xilinx/vivado_console.py
@@ -23,6 +23,7 @@ from click import style
 from ..common import which
 # from ..termui import *
 from ..tcl_console import consolectxmanager, TCLConsoleSnoozer
+from ..tools.common import DEFAULT_ENCODING
 from .vivado_common import VivadoNotFoundError, autodetect, VivadoOutputFormatter, _parseversion
 
 # ------------------------------------------------
@@ -177,7 +178,7 @@ class VivadoConsole(object):
                 ],
             echo=echo,
             logfile=self._out,
-            encoding='utf-8'
+            encoding=DEFAULT_ENCODING,
             # preexec_fn=on_parent_exit('SIGTERM')
         )
 

--- a/src/ipbb/tools/xilinx/vivadohls_console.py
+++ b/src/ipbb/tools/xilinx/vivadohls_console.py
@@ -22,6 +22,7 @@ from click import style
 from ..common import which, OutputFormatter
 from ..termui import *
 from ..tcl_console import consolectxmanager, TCLConsoleSnoozer
+from ..common import DEFAULT_ENCODING
 
 kHLSLogDebug = False
 
@@ -267,6 +268,7 @@ class VivadoHLSConsole(object):
             ],
             echo=echo,
             logfile=self._out,
+            encoding=DEFAULT_ENCODING,
             # preexec_fn=on_parent_exit('SIGTERM')
         )
         


### PR DESCRIPTION
- In Python3, implementing an ```__eq__``` method makes all inherited
  ```__hash__``` methods disappear.
  See also:
  http://docs.python.org/3.1/reference/datamodel.html#object.__hash__
  This applies to the ipbb commands. In absence of a ```__hash__``` method
  there are problems with the tracking of errors, where command
  objects are used as dictionary keys (and hence need to be
  hashable).
- In Python3 the requirements related to operators seem to be a bit
  tighter than in Python2. So an ```__lt__``` method is required for the
  ipbb commands as well. (This is used for sorting.)
- The stdout and stderr results from command execution by sh are
  of type bytes in Python3, so they need to be decoded correctly
  for further output. This is now done based on the default
  encoding (as defined in the locale). This approach based on the
  default encoding was also propagated to all other places that
  so far relied on hard-coded UTF-8.