### PR TITLE
Cosmetic fixes/refinements to output of '--help'

### DIFF
--- a/src/ipbb/cli/common.py
+++ b/src/ipbb/cli/common.py
@@ -5,7 +5,7 @@ import click
 # ------------------------------------------------------------------------------
 @click.command(
     'cleanup',
-    short_help="Clean up the project directory. Delete all files and folders.",
+    help="Clean up the project directory. Delete all files and folders.",
 )
 @click.pass_obj
 @click.pass_context
@@ -21,7 +21,7 @@ def cleanup(ctx, *args, **kwargs):
     return (ctx.command.name, cleanup, args, kwargs)
 
 # ------------------------------------------------------------------------------
-@click.command('user-config', short_help="Manage project-wise user settings.")
+@click.command('user-config', help="Manage project-wise user settings.")
 @click.option('-l', '--list', 'aList', is_flag=True)
 @click.option('-a', '--add', 'aAdd', nargs=2, help='Add a new variable: name value')
 @click.option('-u', '--unset', 'aUnset', nargs=1, help='Remove a variable: name')
@@ -41,7 +41,7 @@ def user_config(ctx, *args, **kwargs):
 
 
 # ------------------------------------------------------------------------------
-@click.command('addrtab', short_help="Gather address table files.")
+@click.command('addrtab', help="Gather address table files.")
 @click.pass_obj
 @click.option('-d', '--dest', 'aDest', default='addrtab')
 @click.pass_context

--- a/src/ipbb/cli/debug.py
+++ b/src/ipbb/cli/debug.py
@@ -4,7 +4,7 @@ import click
 
 
 # ------------------------------------------------------------------------------
-@click.group()
+@click.group('debug', help='Collection of debug/utility commands')
 @click.pass_obj
 def debug(env):
     """Collection of debug/utility commands
@@ -25,7 +25,7 @@ def dump(env):
 
 
 # ------------------------------------------------------------------------------
-@debug.command('ipy')
+@debug.command('ipy', help='Loads the ipbb environment and opens a python shell')
 @click.pass_obj
 @click.pass_context
 def ipy(ctx, env):
@@ -39,7 +39,7 @@ def ipy(ctx, env):
 
 
 # ------------------------------------------------------------------------------
-@debug.command('test-vivado-formatter')
+@debug.command('test-vivado-formatter', help='Test Vivado formatter')
 @click.pass_obj
 def test_vivado_formatter(env):
     """Test vivado formatter
@@ -52,7 +52,7 @@ def test_vivado_formatter(env):
 
 
 # ------------------------------------------------------------------------------
-@debug.command('test-vivado-console')
+@debug.command('test-vivado-console', help='Test Vivado console')
 @click.pass_obj
 def test_vivado_console(env):
     """Test Vivado console

--- a/src/ipbb/cli/ipbus.py
+++ b/src/ipbb/cli/ipbus.py
@@ -2,7 +2,7 @@
 import click
 
 # ------------------------------------------------------------------------------
-@click.group()
+@click.group('ipbus', help='Collection of IPbus-specific commands')
 @click.pass_obj
 def ipbus(env):
     """Collection of ipbus specific commands
@@ -17,7 +17,7 @@ def ipbus(env):
 # ------------------------------------------------------------------------------
 @ipbus.command(
     'gendecoders',
-    short_help='Generate or update the ipbus address decoders references by dep files.',
+    help='Generate or update the ipbus address decoders references by dep files.',
 )
 @click.option('-c', '--check-up-to-date', 'aCheckUpToDate', is_flag=True, help='Checks for out-of-date or missing decoders. Returns error if any of the two are found.')
 @click.option('-f', '--force', 'aForce', is_flag=True, help='Force an update of the address decodes without asking for confirmation.')

--- a/src/ipbb/cli/toolbox.py
+++ b/src/ipbb/cli/toolbox.py
@@ -27,16 +27,12 @@ def check_depfile(env, verbose, toolset, component, depfile):
     check_depfile(env, verbose, toolset, component, depfile)
 
 
-@toolbox.command('vhdl-beautify', short_help="Beautifies VHDL files in components within an ipbb work area or standalone files/directories")
+@toolbox.command('vhdl-beautify', help="Beautifies VHDL files in components within an ipbb work area or standalone files/directories")
 @click.option('-c', '--component', callback=validateMultiplePackageOrComponents, autocompletion=completeComponent, multiple=True)
 @click.option('-p', '--path', type=click.Path(), multiple=True)
 @click.pass_obj
 def vhdl_beautify(env, component, path):
-    '''Perform basic checks on dependency files
-    
-    Args:
-        env (TYPE): Description
-    '''
+    '''Runs code formatter over VHDL files under specified directory'''
     from ..cmds.toolbox import vhdl_beautify
     vhdl_beautify(env, component, path)
 


### PR DESCRIPTION
This PR contains minor changes to ensure that doc strings meant for internal use (e.g. those with `Args:` lists) are not included in the output of `--help`