### PR TITLE
Can again use mem files in ipbb

### DIFF
--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -32,7 +32,7 @@ class VivadoProjectMaker(object):
         elif lExt in ('.xdc', '.tcl'):
             lFileSet = 'constrs_1'
 
-        elif lExt in ('.vhd', '.vhdl', '.v', '.sv', '.ngc', '.edn', '.edf'):
+        elif lExt in ('.vhd', '.vhdl', '.v', '.sv', '.ngc', '.edn', '.edf', '.mem'):
             if aSrcCmd.useInSynth:
                 lFileSet = 'sources_1'
             elif aSrcCmd.useInSim:


### PR DESCRIPTION
This PR (re?)adds the possibility to use .mem files in the dep files to initialise memories that were instantiated using XPMs.

(I could have sworn at some point in 2019 I made a PR with the same effect that was merged.. )