### PR TITLE
Fix access to aSettings on CC7

### DIFF
--- a/src/ipbb/tools/alien.py
+++ b/src/ipbb/tools/alien.py
@@ -173,6 +173,19 @@ class AlienTree(object):
     def __repr__(self):
         return self.__class__.__name__+repr(self._trunk)
 
+    def __getattr__(self, name):
+        try:
+            return self.__getitem__(name)
+        except KeyError:
+            if self._locked or name.startswith('__'):
+                raise
+            else:
+                value = self.__dict__[name] = type(self)()
+                return value
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+
     @property
     def trunk(self):
         return self._trunk


### PR DESCRIPTION
This is a weird one, I think. I couldn't get past the first first steps of `ipbb vivado project`, getting:

```
# ipbb vivado project
generate-project | 
generate-project | - Starting Vivado -----------------------------------------
generate-project | Vivado% 
generate-project | - Started Vivado 2018.3 -----------------------------------------
ERROR ('AttributeError' exception caught): ''AlienTree' object has no attribute 'device_name''

File "/home/gitlab-runner/builds/-53Gy8kU/0/cms-cactus/phase2/firmware/gt-algorithm/build/ipbb-master/src/ipbb/generators/vivadoproject.py", line 55, in write
   print("##### Device name:", aSettings.device_name)
generate-project | quit
```

This PR makes this work for me, but I wonder if there's something specific to my setup as I assume this would have been noticed earlier. I'm on CC7.9 with Python 3.6.8.