### PR TITLE
Fix bug in printing exceptions

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -269,7 +269,7 @@ def synth(env, aNumJobs, aUpdateInt):
         raise click.Abort()
     except RuntimeError as lExc:
         secho(
-            "ERROR: \n" + "\n".join(lExc),
+            "ERROR: " + str(lExc),
             fg='red',
         )
         raise click.Abort()


### PR DESCRIPTION
Updates the vivado `synth` command, to correctly print caught exceptions