### PR TITLE
Fix typo in 'vivado archive' subcommand

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -743,11 +743,9 @@ def package(env, aTag):
 
 
 # ------------------------------------------------------------------------------
-def archive(ctx):
+def archive(env):
 
     lSessionId = 'archive'
-
-    env = ctx.obj
 
     # Check that the project exists 
     ensureVivadoProjPath(env.vivadoProjFile)


### PR DESCRIPTION
At the moment, the `ipbb vivado archive` command fails with the following message: 
```
ERROR ('AttributeError' exception caught): ''Environment' object has no attribute 'obj''

File "/data/tsw/ipbb/ipbb-dev-2020g/src/ipbb/cmds/vivado.py", line 750, in archive
   env = ctx.obj
```

Fix: Remove line 750 in `src/ipbb/cmds/vivado.py` and rename function's argument to `env`