### PR TITLE
Fix import failure: "formatters" is under "cmds" ?

### DIFF
--- a/src/ipbb/utils.py
+++ b/src/ipbb/utils.py
@@ -104,7 +104,7 @@ def ensureNoParsingErrors(aCurrentProj, aDepFileParser):
     if not aDepFileParser.errors:
         return
 
-    from .formatters import DepFormatter
+    from .cmds.formatters import DepFormatter
     fmt = DepFormatter(aDepFileParser)
     secho("ERROR: Project '{}' contains {} parsing error{}.".format(
         aCurrentProj,
@@ -127,7 +127,7 @@ def ensureNoMissingFiles(aCurrentProj, aDepFileParser):
     if not aDepFileParser.unresolved:
         return
 
-    from .formatters import DepFormatter
+    from .cmds.formatters import DepFormatter
     fmt = DepFormatter(aDepFileParser)
     secho("ERROR: Project '{}' contains unresolved dependencies: {} unresolved file{}.".format(
         aCurrentProj,


### PR DESCRIPTION
Depending on the environment, e.g. my local area vs a gitlab CI job, at times I get a failure from this import.
Looking at the code, it seems to me the formatters package is within the cmds, so I think the fix is correct and I have no idea why in some other tests the things work.