### PR TITLE
Add a few more errors to ipbb vivado check-syntax

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -161,7 +161,7 @@ def checksyntax(env):
 
     lSessionId = 'chk-syn'
 
-    lStopOn = ['HDL 9-806', 'HDL 9-69']  # Syntax errors  # Type not declared
+    lStopOn = ['HDL 9-806', 'HDL 9-69', 'HDL 9-3136', 'HDL 9-1752' ]  # Syntax errors  # Type not declared # object not declared # found 0 definitions of operator...
 
     # Check that the project exists 
     ensureVivadoProjPath(env.vivadoProjFile)


### PR DESCRIPTION
From Vivado 2019.2.
These also seem to always result in a failure later in synthesis.