### PR TITLE
Adding quotes stripping to dep line parsing

### DIFF
--- a/src/ipbb/depparser/_fileparser.py
+++ b/src/ipbb/depparser/_fileparser.py
@@ -5,6 +5,7 @@ import glob
 import copy
 import string
 import re
+import shlex
 
 from ._definitions import dep_file_types, dep_command_types
 from ._pathmaker import Pathmaker
@@ -448,7 +449,7 @@ class DepFileParser(object):
                 # --------------------------------------------------------------
                 # Parse the line using arg_parse
                 try:
-                    lParsedCmd = self.parseLine(lLine.split())
+                    lParsedCmd = self.parseLine(shlex.split(lLine))
                 except DepCmdParserError as lExc:
                     lCurrentFile.errors.append((aPackage, aComponent, aDepFileName, lDepFilePath, lLineNr, lLine, lExc))
                     continue


### PR DESCRIPTION
This PR switches to using `shlex.split()` for braking up dep files lines into arguments for `Argparser`.
This allows processing lines like 
```
hlssrc -cflags="-opt1 -opt2"...
```