### PR TITLE
Add simflags argument for HDL sources

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -30,6 +30,7 @@ Mention the minimal requirements for a component (`firmware` subdirectory with c
   - `-l`/`--lib`: Add the hdl file to a library
   - `--vhdl2008`: Use the 2008 vhdl standard for this file
   - `-u`/`--usein` (`synth`,`sim`): Declae the file as synth or sim-only file
+  - `--simflags`: Pass flags to Modelsim/Questasim
 
 * `addrtab`: Add an address table file
   - `-t`/`--toplevel`: Top-level address table
@@ -45,7 +46,7 @@ Mention the minimal requirements for a component (`firmware` subdirectory with c
 
 ## `dep` vs `d3` files
 
-The two file types supported by `ipbb`, `dep` and `d3` (dep-tree), are identical in content, but differ by the order with witch *dep* commands are parsed. 
+The two file types supported by `ipbb`, `dep` and `d3` (dep-tree), are identical in content, but differ by the order with witch *dep* commands are parsed.
 
 `dep` files commands are read from bottom to top and, within the same line, file paths from right to left  Such difference is historical. With this approach the top-level VHDL entity appears at the top of the top dep files, reflecting the file order in the tools (ModelSIM and Vivado). The choice of using a reverse parsing order (dependant entries at the top) has proven counter-intuitive, being inverse of the the ordering used in software context.
 (Additionally, while commands follow the inverse ordering, variables are processed in forward order :facepalm:)

--- a/src/ipbb/depparser/_cmdparser.py
+++ b/src/ipbb/depparser/_cmdparser.py
@@ -47,7 +47,7 @@ class UseInAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
 
         tokens = values.split(',')
-        
+
         lInvalid = [t for t in tokens if t not in self._choices]
         if lInvalid:
             raise ValueError('Invalid source types '+','.join(lInvalid))
@@ -100,6 +100,7 @@ class DepCmdParser(argparse.ArgumentParser):
         subp.add_argument('--cd')
         subp.add_argument('--vhdl2008', action='store_true')
         subp.add_argument('-u', '--usein', action=UseInAction)
+        subp.add_argument('--simflags')
         subp.add_argument('file', nargs='+')
 
         # Source sub-parser
@@ -128,7 +129,7 @@ class DepCmdParser(argparse.ArgumentParser):
 
         self.callbacks = {
             'include' : lambda a : IncludeCommand(a.cmd, a.file, a.component[0], a.component[1], a.cd),
-            'src'     : lambda a : SrcCommand(a.cmd, a.file, a.component[0], a.component[1], a.cd, a.lib, a.vhdl2008, 'synth' in a.usein, 'sim' in a.usein),
+            'src'     : lambda a : SrcCommand(a.cmd, a.file, a.component[0], a.component[1], a.cd, a.lib, a.vhdl2008, 'synth' in a.usein, 'sim' in a.usein, a.simflags),
             'hlssrc'  : lambda a : HlsSrcCommand(a.cmd, a.file, a.component[0], a.component[1], a.cd, a.cflags, a.csimflags, a.tb, a.include_comp),
             'setup'   : lambda a : SetupCommand(a.cmd, a.file, a.component[0], a.component[1], a.cd, a.finalise),
             'addrtab' : lambda a : AddrtabCommand(a.cmd, a.file, a.component[0], a.component[1], a.cd, a.toplevel),
@@ -146,4 +147,3 @@ class DepCmdParser(argparse.ArgumentParser):
         return self.callbacks[cmd](args)
 
 # -----------------------------------------------------------------------------
-

--- a/src/ipbb/depparser/_cmdtypes.py
+++ b/src/ipbb/depparser/_cmdtypes.py
@@ -64,15 +64,17 @@ class SrcCommand(Command):
         vhdl2008   (bool): toggles the vhdl 2008 syntax for .vhd files
         useinsynth (bool): use this files in synth
         useinsim   (bool): use this files in sim
+        simflags   (str):  flags to be passed to Modelsim/Questasim
     """
     # --------------------------------------------------------------
-    def __init__(self, aCmd, aFilePath, aPackage, aComponent, aCd, aLib, aVhdl2008, aUseInSynth, aUseInSim):
+    def __init__(self, aCmd, aFilePath, aPackage, aComponent, aCd, aLib, aVhdl2008, aUseInSynth, aUseInSim, aSimflags):
         super().__init__(aCmd, aFilePath, aPackage, aComponent, aCd)
 
         self.lib = aLib
         self.vhdl2008 = aVhdl2008
         self.useInSynth = aUseInSynth
         self.useInSim = aUseInSim
+        self.simflags = aSimflags
 
     # --------------------------------------------------------------
     def flags(self):
@@ -88,7 +90,7 @@ class SrcCommand(Command):
 
     # --------------------------------------------------------------
     def __eq__(self, other):
-        return (self.filepath == other.filepath) and (self.lib == other.lib)
+        return (self.filepath == other.filepath) and (self.lib == other.lib) and (self.simflags == other.simflags)
 
     __hash__ = object.__hash__
 
@@ -119,7 +121,7 @@ class HlsSrcCommand(Command):
             lFlags.append('tb')
 
         return lFlags
-        
+
     def extra(self):
         if not self.includeComponents:
             return None

--- a/src/ipbb/generators/modelsimproject.py
+++ b/src/ipbb/generators/modelsimproject.py
@@ -98,6 +98,11 @@ class ModelSimGenerator(object):
             else:
                 print(f'# IGNORING unknown source file type in Modelsim build: {src.filepath}')
                 continue
+
+            # ----------------------------------------------------------
+
+            if src.simflags:
+                cmd = f'{cmd} {src.simflags}'
             # ----------------------------------------------------------
 
             lib = src.lib if src.lib else self.simLibrary

--- a/tests/repogen/simple.yml
+++ b/tests/repogen/simple.yml
@@ -11,6 +11,7 @@ files:
       ? var_A == True ? src t2.vhd
       src t3.vhd
       src sim_only.vhd -u sim
+      src sim_only2.vhd -u sim --simflags="-warning 1594"
       src synth_only.vhd -u synth
     defs.dep: |
       @var_A=False
@@ -24,5 +25,5 @@ files:
     d1.vhd: ""
     d2.vhd: ""
     sim_only.vhd: "# Only used in simulation"
+    sim_only2.vhd: "# Only used in simulation"
     synth_only.vhd: "# Only used in synhesis"
-

--- a/tests/repogen/simple_d3.yml
+++ b/tests/repogen/simple_d3.yml
@@ -7,7 +7,7 @@ files:
     top.d3: |
       setup settings.tcl
       src t0.vhd
-      src t1.vhd
+      src --simflags="-warning 1594" t1.vhd
       include defs.d3
       ? var_A == True ? src t2.vhd
       src t3.vhd


### PR DESCRIPTION
Hi,

In some cases it's quite useful to be able to pass special flags to Modelsim and Questasim. (e.g. at the moment I'm working around a dislike between TCDS2 sources and Modelsim where I need to downgrade an error to a warning with the `-warning [err no]` flag) With the `--simflags` argument one can now pass these options to Modelsim/Questasim.

Cheers,
Dinyar