### PR TITLE
Fix small typo in ipbus cmd

### DIFF
--- a/src/ipbb/cmds/ipbus.py
+++ b/src/ipbb/cmds/ipbus.py
@@ -95,7 +95,7 @@ def gendecoders(ictx, aCheckUpToDate, aForce):
         # ------------------------------------------------------------------------------
         cprint(
             'The following decoders have changed and must be updated:\n'
-            + '\n'.join([f" * [blue]{d}[/blue]" for d in UpdatedDecoders])
+            + '\n'.join([f" * [blue]{d}[/blue]" for d in lUpdatedDecoders])
             + '\n'
         )
         if aCheckUpToDate:


### PR DESCRIPTION
While testing the other PR I noticed that the decoder command crashed. I think this is the culprit.

Cheers,
Dinyar
