### PR TITLE
Vivado loglevel control

### DIFF
--- a/src/ipbb/__init__.py
+++ b/src/ipbb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0.dev21_i'
+__version__ = '1.0.0.dev21_j'
 
 # from . import cli
 # from . import tools

--- a/src/ipbb/cli/vivado.py
+++ b/src/ipbb/cli/vivado.py
@@ -8,9 +8,9 @@ import importlib
 # ------------------------------------------------------------------------------
 @click.group('vivado', short_help='Set up, syntesize, implement Vivado projects.', chain=True)
 @click.option('-p', '--proj', default=None, help="Selected project, if not current")
-@click.option('-v', '--verbosity', type=click.Choice(['all', 'warnings-only', 'none']), default='all', help="Silence vivado messages")
+@click.option('-l', '--loglevel', type=click.Choice(['all', 'info', 'warn', 'cwarn', 'error', 'fatal', 'none']), default='all', help="Silence vivado messages")
 @click.pass_obj
-def vivado(ictx, proj, verbosity):
+def vivado(ictx, proj, loglevel):
     '''Vivado command group
     
     \b
@@ -26,10 +26,10 @@ def vivado(ictx, proj, verbosity):
 # ------------------------------------------------------------------------------
 @vivado.resultcallback()
 @click.pass_obj
-def process_vivado(ictx, subcommands, proj, verbosity):
+def process_vivado(ictx, subcommands, proj, loglevel):
 
     from ..cmds.vivado import vivado
-    vivado(ictx, proj, verbosity, (name for name,_,_,_ in subcommands))
+    vivado(ictx, proj, loglevel, (name for name,_,_,_ in subcommands))
 
     # Executed the chained commands
     for name, cmd, args, kwargs in subcommands:

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -79,20 +79,20 @@ def ensureVivadoProjPath(aProjPath: str):
         raise click.ClickException("Vivado project %s does not exist" % aProjPath)
 
 # ------------------------------------------------------------------------------
-def vivado(ictx, proj, verbosity, cmdlist):
+def vivado(ictx, proj, loglevel, cmdlist):
     '''Vivado command group
     
     Args:
         ctx (click.Context): Command context
         ictx (ipbb.Context): Context object
         proj (str): Project name
-        verbosity (str): Verbosity level
+        loglevel (str): Verbosity level
     
     Raises:
         click.ClickException: Undefined project area
     '''
 
-    ictx.vivadoEcho = (verbosity == 'all')
+    # ictx.vivadoEcho = 
 
     # lProj = proj if proj is not None else ictx.currentproj.name
     if proj is not None:
@@ -117,7 +117,7 @@ def vivado(ictx, proj, verbosity, cmdlist):
     ictx.vivadoProdPath = join(ictx.currentproj.path, 'products')
     ictx.vivadoProdFileBase = join(ictx.vivadoProdPath, ictx.currentproj.name)
 
-    ictx.vivadoSessions = VivadoSessionManager(keep=lKeep, loglabel=lLogLabel)
+    ictx.vivadoSessions = VivadoSessionManager(keep=lKeep, echo=(loglevel != 'none'), loglabel=lLogLabel, loglevel=loglevel)
 
     ensureVivado(ictx)
 

--- a/src/ipbb/tools/xilinx/vivado_console.py
+++ b/src/ipbb/tools/xilinx/vivado_console.py
@@ -120,7 +120,7 @@ class VivadoConsole(object):
     # --------------------------------------------------------------
 
     # --------------------------------------------------------------
-    def __init__(self, executable='vivado', prompt=None, stopOnCWarnings=False, echo=True, showbanner=False, sid=None, loglabel=None):
+    def __init__(self, executable='vivado', prompt=None, stopOnCWarnings=False, echo=True, showbanner=False, sid=None, loglabel=None, loglevel='all'):
         """
         Args:
             executable (str): Executable name
@@ -128,8 +128,8 @@ class VivadoConsole(object):
             stopOnCWarnings (bool): Stop on Critical Warnings
             echo (bool): Switch to enable echo messages
             showbanner (bool, optional): Show Vivado startup banner
-            echoprefix (str): Prefix to echo message
-            loglabel (None, optional): Description
+            sid (str): Session id
+            loglabel (None, optional): log files name
         
         Raises:
             VivadoNotFoundError: Description
@@ -156,7 +156,7 @@ class VivadoConsole(object):
 
         # Set up the output formatter
         self._out = VivadoOutputFormatter(
-            sid, quiet=(not echo)
+            sid, loglevel=loglevel
         )
 
         self._out.write('\n' + '- Starting Vivado -'+'-' * 40 + '\n')
@@ -437,7 +437,7 @@ class VivadoSessionManager(object):
     Attributes:
         persistent (TYPE): Description
     """
-    def __init__(self, keep=False, echo=True, loglabel=None):
+    def __init__(self, keep=False, echo=True, loglabel=None, loglevel='all'):
         """Constructor
         
         Args:
@@ -447,6 +447,7 @@ class VivadoSessionManager(object):
         self._keep = keep
         self._echo = echo
         self._loglabel = loglabel
+        self._loglevel = loglevel
         if self._keep:
             self._console = None
 
@@ -458,11 +459,11 @@ class VivadoSessionManager(object):
 
         if self._keep:
             if not self._console:
-                self._console = VivadoConsole(sid=sid, loglabel=self._loglabel, echo=self._echo)
+                self._console = VivadoConsole(sid=sid, loglabel=self._loglabel, echo=self._echo, loglevel=self._loglevel)
             self._console.sessionid = sid
             return self._console
         else:
-            return VivadoConsole(sid=sid, loglabel=self._loglabel, echo=self._echo)
+            return VivadoConsole(sid=sid, loglabel=self._loglabel, echo=self._echo, loglevel=self._loglevel)
 
 
     def getctx(self, sid):

--- a/tests/pytests/test_xilinx.py
+++ b/tests/pytests/test_xilinx.py
@@ -14,7 +14,6 @@ def check_vivado_env():
         RuntimeError: Description
     """
     print(os.environ['XILINX_VIVADO'])
-    # raise RuntimeError('SSSS')
 
 
 def test_autodetect(check_vivado_env):


### PR DESCRIPTION
Replaces the obsolete `vivado --verbosity` flag with `vivado --loglevel`, that allows fine-grain control on vivado's log messages display to console.

Closes #151 