### PR TITLE
Turn spurious IP upgrade warnings into info messages

### DIFF
--- a/src/ipbb/generators/ipcoressim.py
+++ b/src/ipbb/generators/ipcoressim.py
@@ -92,6 +92,9 @@ class IPCoresSimGenerator(object):
                     lXCIs.append( (lName, lBasename) )
 
         if lXCIs:
+            # Turn 'WARNING: [Coretcl 2-1042] No IP was identified for
+            # upgrade.' into INFO messags.
+            write(f'set_msg_config -id {{Coretcl 2-1042}} -new_severity {{INFO}}')
             lIPs, lIPFiles = zip(*lXCIs)
             write(f'upgrade_ip [get_ips {" ".join(lIPs)}]')
 

--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -220,6 +220,10 @@ class VivadoProjectGenerator(object):
         if self.ipCachePath:
             write(f'config_ip_cache -import_from_project -use_cache_location {abspath(self.ipCachePath)}')
 
+        # Turn 'WARNING: [Coretcl 2-1042] No IP was identified for
+        # upgrade.' into INFO messags.
+        write(f'set_msg_config -id {{Coretcl 2-1042}} -new_severity {{INFO}}')
+
         for i in lIPNames:
             write(f'upgrade_ip [get_ips {i}]')
 


### PR DESCRIPTION
When using the upgrade_ip TCL command on an IP core that does not
need upgrading, a warning is issued:
'WARNING: [Coretcl 2-1042] No IP was identified for upgrade.'
This is distracting when scraping the output for real warnings. This
commit turns those warnings into info messages.