### PR TITLE
Avoid Vivado (2021.2 only?) throwing errors due to repeated calls to set_msg_config

### DIFF
--- a/src/ipbb/tools/xilinx/vivado_console.py
+++ b/src/ipbb/tools/xilinx/vivado_console.py
@@ -382,7 +382,7 @@ class VivadoConsole(object):
             aSeverity (str): Target severity
         """
         lIds = aIds if isinstance(aIds, list) else [aIds]
-        for c in ('set_msg_config -id {{{}}} -new_severity {{{}}}'.format(i, aSeverity) for i in lIds):
+        for c in ('reset_msg_config -id {{{}}} -default_severity; set_msg_config -id {{{}}} -new_severity {{{}}}'.format(i, i, aSeverity) for i in lIds):
             self.execute(c)
 
 


### PR DESCRIPTION
It appears that recent versions of Vivado (2021.2 in any case) don't always like repeated calls to set_msg_config with the same rules.

This is what (sometimes?) happens in the Vivado TCL console:
`set_msg_config -id {Timing 38-282} -new_severity {ERROR}

WARNING: [Common 17-1361] You have specified a new message control rule that is equivalent to an existing rule with attributes ' -id {Timing 38-282}  -new_severity {ERROR} '. The existing rule will be replaced.

ERROR: [Common 17-39] 'set_msg_config' failed due to earlier errors.`

The way around this (that always works) is to remove the rule beforehand, using reset_msg_config. That is what this little patch does.