### PR TITLE
gendecoders: add command line option for generator template file

### DIFF
--- a/src/ipbb/cli/ipbus.py
+++ b/src/ipbb/cli/ipbus.py
@@ -21,12 +21,13 @@ def ipbus(env):
 )
 @click.option('-c', '--check-up-to-date', 'aCheckUpToDate', is_flag=True, help='Checks for out-of-date or missing decoders. Returns error if any of the two are found.')
 @click.option('-f', '--force', 'aForce', is_flag=True, help='Force an update of the address decodes without asking for confirmation.')
+@click.option('-t', '--template', 'aTemplate', type=click.Path(), help='Path to IPbus address decoder VHDL template.')
 @click.pass_obj
-def gendecoders(env, aCheckUpToDate, aForce):
+def gendecoders(env, aCheckUpToDate, aForce, aTemplate):
     """Generates the ipbus address decoder modules
     
     Args:
         env (`obj`): Click context
     """
     from ..cmds.ipbus import gendecoders
-    gendecoders(env, aCheckUpToDate, aForce)
+    gendecoders(env, aCheckUpToDate, aForce, aTemplate)

--- a/src/ipbb/cmds/ipbus.py
+++ b/src/ipbb/cmds/ipbus.py
@@ -19,7 +19,7 @@ def ipbus(ictx):
     pass
 
 # ------------------------------------------------------------------------------
-def gendecoders(ictx, aCheckUpToDate, aForce):
+def gendecoders(ictx, aCheckUpToDate, aForce, aTemplate):
 
     lDecodersDir = 'decoders'
 
@@ -39,6 +39,7 @@ def gendecoders(ictx, aCheckUpToDate, aForce):
 
     lUpdatedDecoders = []
     lGen = sh.Command(which(lGenScript))
+    lTemplateArg = f"--template={aTemplate}" if aTemplate else None
     lErrors = {}
     with DirSentry(join(ictx.currentproj.path, lDecodersDir)):
         for lAddr in ictx.depParser.commands['addrtab']:
@@ -53,7 +54,7 @@ def gendecoders(ictx, aCheckUpToDate, aForce):
 
             # Generate a new decoder file
             try:
-                lGen(basename(lAddr.filepath), _out=sys.stdout, _err=sys.stderr, _tee=True)
+                lGen(basename(lAddr.filepath), lTemplateArg, _out=sys.stdout, _err=sys.stderr, _tee=True)
             except Exception as lExc:
                 cprint(f"Failed to generate decoder for {basename(lAddr.filepath)}", style='red')
                 lErrors[lAddr] = lExc


### PR DESCRIPTION
This PR allows specifying the IPbus address decoder VHDL template file through IPBB. This is currently not possible, and as such any non-standard ipbus-software installations (in places other than `/opt/cactus`) won't work.