### PR TITLE
gitignore: ignore egg-info files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
+*.egg-info
 venv/ipbb
 .vscode


### PR DESCRIPTION
Ignore egg-info files created when building this package in editable/developer mode (pip install -e).