### PR TITLE
Depfile errors: Wrap filenames onto next line

### DIFF
--- a/src/ipbb/cmds/toolbox.py
+++ b/src/ipbb/cmds/toolbox.py
@@ -107,7 +107,9 @@ def check_depfile(env, verbose, toolset, component, depfile):
     if lFNF:
         cprint('Missing files:', style='red')
 
-        lFNFTable = Table('path', 'included by')
+        lFNFTable = Table()
+        lFNFTable.add_column('path', overflow='fold')
+        lFNFTable.add_column('included by', overflow='fold')
         for pkg in sorted(lFNF):
             lCmps = lFNF[pkg]
             for cmp in sorted(lCmps):

--- a/src/ipbb/depparser/_formatters.py
+++ b/src/ipbb/depparser/_formatters.py
@@ -147,7 +147,11 @@ class DepFormatter(object):
         if not lFNF:
             return ""
 
-        lFNFTable = Table('path expression', 'package', 'component', 'included by')
+        lFNFTable = Table()
+        lFNFTable.add_column('path expression', overflow='fold')
+        lFNFTable.add_column('package', overflow='fold') 
+        lFNFTable.add_column('component', overflow='fold')
+        lFNFTable.add_column('included by', overflow='fold')
         # lFNFTable.set_deco(Texttable.HEADER | Texttable.BORDER)
 
         for pkg in sorted(lFNF):


### PR DESCRIPTION
This branch updates functions that print depfile errors, in order to make sure that long filenames are wrapped to the next line rather than the end of the path being replaced with `...`. For example, the following error:
```
Missing files:
    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
    ┃ path TEST                                                            ┃ included by                                                         ┃
    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
    │ emp-fwk/projects/examples/serenity/dc_vu9p/firmware/hdl/so2/emp_pro… │ emp-fwk/projects/examples/serenity/dc_vu9p/firmware/cfg/so2/top.dep │
    └──────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────┘
```

... becomes:
```
Missing files:
    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
    ┃ path                                                                 ┃ included by                                                         ┃
    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
    │ emp-fwk/projects/examples/serenity/dc_vu9p/firmware/hdl/so2/emp_proj │ emp-fwk/projects/examples/serenity/dc_vu9p/firmware/cfg/so2/top.dep │
    │ ect_decll.vhd                                                        │                                                                     │
    └──────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────┘
```