### PR TITLE
Work-around for stuck terminal on RHEL8-based systems

### DIFF
--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -7,6 +7,7 @@ import textwrap
 
 from string import Template as tmpl
 from ..defaults import kTopEntity
+from ..utils import read_os_release
 from os.path import abspath, join, split, splitext
 
 
@@ -174,25 +175,35 @@ class VivadoProjectGenerator(object):
             cmd_types = ['ip', 'add', 'prop']
             if not set(lSrcCommandGroups.keys()).issubset(cmd_types):
                 raise RuntimeError(f"Command group mismatch {' '.join(lSrcCommandGroups.keys())}")
+            # There seems to be a terminal problem on RHEL 8-based
+            # systems that hangs on long commands. For those platforms
+            # we apply a work-around.
+            os_info = read_os_release()
+            need_workaround = os_info \
+                and (os_info['PLATFORM_ID'] == 'platform:el8')
             for t in cmd_types:
                 if t in lSrcCommandGroups:
                     for c, f in lSrcCommandGroups[t].items():
-                        # NOTE: For some reason, pexpect.sendline() in
-                        # the Vivado console implementation hangs when
-                        # the commands sent are too long. The exact
-                        # limit is not clear, but empiric checks seem
-                        # to indicate that 33k characters is too
-                        # long. Therefore long commands (i.e., longer
-                        # than a somewhat arbitrary length) are split
-                        # up into multiple commands.
-                        MAX_FILES_LEN = 8192
                         files = ' '.join(f)
-                        files_split = textwrap.wrap(files,
-                                                    MAX_FILES_LEN,
-                                                    break_long_words=False,
-                                                    break_on_hyphens=False)
-                        for tmp_files in files_split:
-                            write(tmpl(c).substitute(files=tmp_files))
+                        if not need_work_around:
+                            write(tmpl(c).substitute(files=files))
+                        else:
+                            # For some reason, pexpect.sendline() in
+                            # the Vivado console implementation hangs
+                            # when the commands sent are too long. The
+                            # exact limit is not clear, but empiric
+                            # checks seem to indicate that 33k
+                            # characters is too long. Therefore long
+                            # commands (i.e., longer than a somewhat
+                            # arbitrary length) are split up into
+                            # multiple commands.
+                            MAX_FILES_LEN = 8192
+                            files_split = textwrap.wrap(files,
+                                                        MAX_FILES_LEN,
+                                                        break_long_words=False,
+                                                        break_on_hyphens=False)
+                            for tmp_files in files_split:
+                                write(tmpl(c).substitute(files=tmp_files))
 
         write(f'set_property top {lTopEntity} [get_filesets sources_1]')
         if lSimTopEntity:

--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -3,6 +3,7 @@ import time
 import os
 import collections
 import copy
+import textwrap
 
 from string import Template as tmpl
 from ..defaults import kTopEntity
@@ -176,7 +177,22 @@ class VivadoProjectGenerator(object):
             for t in cmd_types:
                 if t in lSrcCommandGroups:
                     for c, f in lSrcCommandGroups[t].items():
-                        write(tmpl(c).substitute(files=' '.join(f)))
+                        # NOTE: For some reason, pexpect.sendline() in
+                        # the Vivado console implementation hangs when
+                        # the commands sent are too long. The exact
+                        # limit is not clear, but empiric checks seem
+                        # to indicate that 33k characters is too
+                        # long. Therefore long commands (i.e., longer
+                        # than a somewhat arbitrary length) are split
+                        # up into multiple commands.
+                        MAX_FILES_LEN = 8192
+                        files = ' '.join(f)
+                        files_split = textwrap.wrap(files,
+                                                    MAX_FILES_LEN,
+                                                    break_long_words=False,
+                                                    break_on_hyphens=False)
+                        for tmp_files in files_split:
+                            write(tmpl(c).substitute(files=tmp_files))
 
         write(f'set_property top {lTopEntity} [get_filesets sources_1]')
         if lSimTopEntity:

--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -185,7 +185,7 @@ class VivadoProjectGenerator(object):
                 if t in lSrcCommandGroups:
                     for c, f in lSrcCommandGroups[t].items():
                         files = ' '.join(f)
-                        if not need_work_around:
+                        if not need_workaround:
                             write(tmpl(c).substitute(files=files))
                         else:
                             # For some reason, pexpect.sendline() in

--- a/src/ipbb/utils/utils.py
+++ b/src/ipbb/utils/utils.py
@@ -1,5 +1,8 @@
 # NOTE TO SELF: Merge with tools/common.py
 
+import csv
+import pathlib
+import platform
 import os
 import ipaddress
 import sys
@@ -16,6 +19,26 @@ from locale import getpreferredencoding
 from ..console import cprint, console
 
 DEFAULT_ENCODING = getpreferredencoding() or "UTF-8"
+
+# ------------------------------------------------------------------------------
+def read_os_release():
+    """Check OS, and on Linux return a dictionary with /etc/os-release info
+
+    On any platform other than Linux, None is returned.
+
+    """
+
+    res = None
+    if platform.system() == 'Linux':
+        in_file_name = pathlib.Path("/etc/os-release")
+        with open(in_file_name) as in_stream:
+            non_empty_lines = (l for l in in_stream if not l.isspace())
+            reader = csv.reader(non_empty_lines, delimiter="=")
+            res = dict(reader)
+
+    return res
+# ------------------------------------------------------------------------------
+
 
 # ------------------------------------------------------------------------------
 class DirSentry:


### PR DESCRIPTION
As we discussed yesterday.
Tested (a little, not in anger) on a Centos Stream 8 machine, and on an Alma 8 machine.