### PR TITLE
Robustify the RHEL8 check and fix a typo

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -221,7 +221,7 @@ def checksyntax(ictx):
         raise click.Abort()
 
     console.log(
-        "\n{}: Synthax check completed successfully.\n".format(ictx.currentproj.name),
+        "\n{}: Syntax check completed successfully.\n".format(ictx.currentproj.name),
         style='green',
     )
 

--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -180,7 +180,7 @@ class VivadoProjectGenerator(object):
             # we apply a work-around.
             os_info = read_os_release()
             need_workaround = os_info \
-                and (os_info['PLATFORM_ID'] == 'platform:el8')
+                and (os_info.get('REDHAT_SUPPORT_PRODUCT_VERSION', None) == '8')
             for t in cmd_types:
                 if t in lSrcCommandGroups:
                     for c, f in lSrcCommandGroups[t].items():

--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -179,8 +179,10 @@ class VivadoProjectGenerator(object):
             # systems that hangs on long commands. For those platforms
             # we apply a work-around.
             os_info = read_os_release()
-            need_workaround = os_info \
-                and (os_info.get('REDHAT_SUPPORT_PRODUCT_VERSION', None) == '8')
+            redhat_support_product_version = os_info \
+                and os_info.get('REDHAT_SUPPORT_PRODUCT_VERSION', None)
+            need_workaround = redhat_support_product_version \
+                and 8 <= float(redhat_support_product_version) < 9
             for t in cmd_types:
                 if t in lSrcCommandGroups:
                     for c, f in lSrcCommandGroups[t].items():


### PR DESCRIPTION
Two small changes:

- Be more careful with the check for RHEL8-based systems. Now fully backward compatible with CentOS 7 as well.
- Fix a distracting typo in an output message.