### PR TITLE
Improve support for .tcl constraints files

### DIFF
--- a/src/ipbb/depparser/_cmdtypes.py
+++ b/src/ipbb/depparser/_cmdtypes.py
@@ -62,16 +62,17 @@ class SrcCommand(Command):
         cmd        (str):  command directive
         filepath   (str):  absolute, normalised path to the command target.
         package    (str):  package the target belongs to.
-        component  (str):  component withon 'Package' the target belongs to
+        component  (str):  component within 'Package' the target belongs to
         lib        (str):  library the file will be added to
         vhdl2008   (bool): toggles the vhdl 2008 syntax for .vhd files
         vhdl2019   (bool): toggles the vhdl 2019 syntax for .vhd files
-        useinsynth (bool): use this files in synth
-        useinsim   (bool): use this files in sim
+        useinsynth (bool): use this file in synth
+        useinsim   (bool): use this file in sim
+        usefor     (str):  use specification for constraint files
         simflags   (str):  flags to be passed to Modelsim/Questasim
     """
     # --------------------------------------------------------------
-    def __init__(self, aCmd, aFilePath, aPackage, aComponent, aCd, aLib, aVhdl2008, aVhdl2019, aUseInSynth, aUseInSim, aSimflags):
+    def __init__(self, aCmd, aFilePath, aPackage, aComponent, aCd, aLib, aVhdl2008, aVhdl2019, aUseInSynth, aUseInSim, aUseFor, aSimflags):
         super().__init__(aCmd, aFilePath, aPackage, aComponent, aCd)
 
         self.lib = aLib
@@ -79,6 +80,7 @@ class SrcCommand(Command):
         self.vhdl2019 = aVhdl2019
         self.useInSynth = aUseInSynth
         self.useInSim = aUseInSim
+        self.useFor = aUseFor
         self.simflags = aSimflags
 
     # --------------------------------------------------------------
@@ -97,7 +99,7 @@ class SrcCommand(Command):
 
     # --------------------------------------------------------------
     def __eq__(self, other):
-        return (self.filepath == other.filepath) and (self.lib == other.lib) and (self.simflags == other.simflags)
+        return (self.filepath == other.filepath) and (self.lib == other.lib) and (self.simflags == other.simflags) and (self.useFor == other.useFor)
 
     # --------------------------------------------------------------
     def __hash__(self):

--- a/src/ipbb/depparser/_fileparser.py
+++ b/src/ipbb/depparser/_fileparser.py
@@ -499,6 +499,9 @@ class DepFileParser(object):
                 except DepCmdParserError as lExc:
                     lCurrentFile.errors.append((aPackage, aComponent, aDepFileName, lDepFilePath, lLineNr, lLine, lExc))
                     continue
+                except Exception as lExc:
+                    lCurrentFile.errors.append((aPackage, aComponent, aDepFileName, lDepFilePath, lLineNr, lLine, lExc))
+                    continue
 
                 if self._verbosity > 1:
                     print(self._state.tab, '- Parsed line', vars(lParsedCmd))

--- a/src/ipbb/generators/vivadoproject.py
+++ b/src/ipbb/generators/vivadoproject.py
@@ -148,9 +148,9 @@ class VivadoProjectGenerator(object):
                     f = src.filepath
                     lCommands += [(t, c, f)]
 
-                if ext == '.tcl':
+                if ext in ['.tcl', '.xdc']:
                     t = 'prop'
-                    c = 'set_property USED_IN implementation [get_files {$files}]'
+                    c = f'set_property USED_IN {{{" ".join(src.useFor)}}} [get_files {{$files}}]'
                     f = src.filepath
                     lCommands += [(t, c, f)]
 


### PR DESCRIPTION
So far, ipbb treated xdc and tcl constraints files differently. XDC files would follow the default Vivado behaviour, and be used for both synthesis and implementation. TCL files would only be used in implementation.

These changes make both xdc and tcl constraints files follow the default Vivado behaviour, and add an optional '--usefor' flag in the dependency files to specify where/when to use the file. For example: '--usefor implementation', to only use the file in the implementation step, or '--usefor synthesis,implementation', to use the file in both the synthesis and the implementation step.