### PR TITLE
Make sure to return non-zero exit code for 'dep report'

### DIFF
--- a/src/ipbb/cmds/dep.py
+++ b/src/ipbb/cmds/dep.py
@@ -149,6 +149,7 @@ def report(ictx, pager, filters):
 
         if lDepFmt.hasErrors():
             cprint(Panel.fit(lDepFmt.draw_error_table(), title='[bold red]dep tree errors[/bold red]'))
+            raise click.ClickException("Detected errors in dep tree")
 
 
 


### PR DESCRIPTION
Make sure to return non-zero exit code for 'dep report' in case of errors in dep tree