### PR TITLE
Raise SystemExit(1) instead of ClickException in 'dep report'

### DIFF
--- a/src/ipbb/cmds/dep.py
+++ b/src/ipbb/cmds/dep.py
@@ -149,7 +149,7 @@ def report(ictx, pager, filters):
 
         if lDepFmt.hasErrors():
             cprint(Panel.fit(lDepFmt.draw_error_table(), title='[bold red]dep tree errors[/bold red]'))
-            raise click.ClickException("Detected errors in dep tree")
+            raise SystemExit(1)
 
 
 


### PR DESCRIPTION
In case of unresolved files in the 'dep report' stage, ipbb will now exit with exit code 1, but without explicitly error message to the user. The 'dep report' command, after all, did not result in any error. This matches the behaviour of the diff utility.

(As discussed per email.)