### PR TITLE
Implement the use of '\' for line continuation in dependency files

### DIFF
--- a/src/ipbb/depparser/_fileparser.py
+++ b/src/ipbb/depparser/_fileparser.py
@@ -463,13 +463,27 @@ class DepFileParser(object):
         self._depregistry[lDepFilePath] = lCurrentFile
 
         with open(lDepFilePath) as lDepFile:
-            for lLineNr, lLine in enumerate(lDepFile):
+            lLinePrev = ""
+            for lLineNr, lLineRaw in enumerate(lDepFile):
 
                 lDepInfo = (lCurrentFile.full_path(), lLineNr)
 
                 # --------------------------------------------------------------
                 # Pre-processing
                 try:
+                    # See if this is a split line or not.
+                    LINE_SPLIT_CHARACTER = "\\"
+                    if lLineRaw.strip().endswith(LINE_SPLIT_CHARACTER):
+                        lLinePrev += lLineRaw.strip()[:-1]
+                        continue
+                    else:
+                        lLine = (lLinePrev.strip() + " " + lLineRaw.strip()).strip()
+                        if lLinePrev:
+                            print(f"DEBUG JGH '{lLine}'")
+                            import pdb
+                            pdb.set_trace()
+                        lLinePrev = ""
+
                     # Sanitize/drop comments
                     lLine = self._line_drop_Comments(lLine, lDepInfo)
                     if not lLine:

--- a/src/ipbb/depparser/_fileparser.py
+++ b/src/ipbb/depparser/_fileparser.py
@@ -473,11 +473,15 @@ class DepFileParser(object):
                 try:
                     # See if this is a split line or not.
                     LINE_SPLIT_CHARACTER = "\\"
-                    if lLineRaw.strip().endswith(LINE_SPLIT_CHARACTER):
-                        lLinePrev += lLineRaw.strip()[:-1]
+                    lLineRawStripped = lLineRaw.rstrip()
+                    if lLineRawStripped.endswith(LINE_SPLIT_CHARACTER):
+                        if lLinePrev:
+                            lLinePrev = lLinePrev + " " + lLineRawStripped[:-1].strip()
+                        else:
+                            lLinePrev = lLineRawStripped[:-1].rstrip()
                         continue
                     else:
-                        lLine = (lLinePrev.strip() + " " + lLineRaw.strip()).strip()
+                        lLine = lLinePrev + " " + lLineRawStripped.strip()
                         lLinePrev = ""
 
                     # Sanitize/drop comments

--- a/src/ipbb/depparser/_fileparser.py
+++ b/src/ipbb/depparser/_fileparser.py
@@ -478,10 +478,6 @@ class DepFileParser(object):
                         continue
                     else:
                         lLine = (lLinePrev.strip() + " " + lLineRaw.strip()).strip()
-                        if lLinePrev:
-                            print(f"DEBUG JGH '{lLine}'")
-                            import pdb
-                            pdb.set_trace()
                         lLinePrev = ""
 
                     # Sanitize/drop comments


### PR DESCRIPTION
Some of the lines in the dependency files, especially for the conditional cases, can become quite long. This change implements 'line continuation' for lines ending in '\'. The implementation is a bit naive/straightforward. There is no real grammar behind the dependency file parsing anyway, so this should not be too offensive.