### PR TITLE
Fixes error when checking out git revision

### DIFF
--- a/src/ipbb/cmds/repo.py
+++ b/src/ipbb/cmds/repo.py
@@ -303,7 +303,7 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
         sh.git(*lCloneArgs, _out=sys.stdout, _cwd=ictx.srcdir)
         cprint('Checking out revision [blue]{}[/blue]'.format(revision))
         try:
-            lFetchArgs = ['fetch', 'origin', revision, '-q']
+            lFetchArgs = ['fetch', 'origin', '-q']
             if depth is not None:
                 lFetchArgs += [f'--depth={depth}']
             sh.git(*lFetchArgs, _out=sys.stdout, _cwd=lRepoLocalPath)


### PR DESCRIPTION
When checking out a specific commit, the function would fail and revert to staying at the HEAD of the master branch.

This fix should fetch, then checkout the commit.

Previous behaviour:
```
# ipbb add git https://gitlab.cern.ch/HPTD/tclink.git -r fda0bcf
Adding git repository https://gitlab.cern.ch/HPTD/tclink.git
Checking out revision fda0bcf
Failed to check out requested revision. Staying on default branch.
Repository 'tclink' successfully cloned to:
  /work/src/tclink
No init configuration file. Skipping.
```

Error raised (when raising in except block):
```
ipbb add git https://gitlab.cern.ch/HPTD/tclink.git -r fda0bcf
Adding git repository https://gitlab.cern.ch/HPTD/tclink.git
Checking out revision fda0bcf
Failed to check out requested revision. Staying on default branch.
ERROR: exception caught!


  RAN: /usr/bin/git fetch origin fda0bcf -q

  STDOUT:


  STDERR:
fatal: couldn't find remote ref fda0bcf
```