### PR TITLE
ipbb add: Git clone fixes

### DIFF
--- a/src/ipbb/cmds/repo.py
+++ b/src/ipbb/cmds/repo.py
@@ -284,20 +284,15 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
             )
         )
 
-    lCloneArgs = ['clone', repo]
-
-    if dest is not None:
-        lCloneArgs += [dest]
-
-    if depth is not None:
-        lCloneArgs += [f'--depth={depth}']
-
     # NOTE: The mutual exclusivity of checking out a branch and
     # checkout out a revision should have been handled at the CLI
     # option handling stage.
     if revision is not None:
-        sh.git(*lCloneArgs, _out=sys.stdout, _cwd=ictx.srcdir)
-        cprint('Checking out revision [blue]{}[/blue]'.format(revision))
+        if dest is None:
+            dest = pathlib.Path(repo).stem
+        sh.git('init', dest, _out=sys.stdout, _cwd=ictx.srcdir)
+        sh.git('remote', 'add', repo, _out=sys.stdout, _cwd=ictx.srcdir)
+        cprint('Fetching & checking out revision [blue]{}[/blue]'.format(revision))
         try:
             lFetchArgs = ['fetch', 'origin', revision, '-q']
             if depth is not None:
@@ -312,6 +307,14 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
             cprint("Failed to check out requested revision." \
                   " Staying on default branch.", style='red')
     else:
+        lCloneArgs = ['clone', repo]
+
+        if dest is not None:
+            lCloneArgs += [dest]
+
+        if depth is not None:
+            lCloneArgs += [f'--depth={depth}']
+
         if branch_or_tag is None:
             cprint(f'Cloning default branch')
         else:

--- a/src/ipbb/cmds/repo.py
+++ b/src/ipbb/cmds/repo.py
@@ -295,11 +295,7 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
     # NOTE: The mutual exclusivity of checking out a branch and
     # checkout out a revision should have been handled at the CLI
     # option handling stage.
-    if branch_or_tag is not None:
-        cprint(f'Cloning branch/tag [blue]{branch_or_tag}[/blue]')
-        sh.git(*lCloneArgs, f'--branch={branch_or_tag}', _out=sys.stdout, _cwd=ictx.srcdir)
-
-    elif revision is not None:
+    if revision is not None:
         sh.git(*lCloneArgs, _out=sys.stdout, _cwd=ictx.srcdir)
         cprint('Checking out revision [blue]{}[/blue]'.format(revision))
         try:
@@ -315,6 +311,13 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
             # hard reference could be found.)
             cprint("Failed to check out requested revision." \
                   " Staying on default branch.", style='red')
+    else:
+        if branch_or_tag is None:
+            cprint(f'Cloning default branch')
+        else:
+            lCloneArgs.append(f'--branch={branch_or_tag}')
+            cprint(f'Cloning branch/tag [blue]{branch_or_tag}[/blue]')
+        sh.git(*lCloneArgs, _out=sys.stdout, _cwd=ictx.srcdir)
 
     cprint(
         'Repository \'{}\' successfully cloned to:\n  {}'.format(

--- a/src/ipbb/cmds/repo.py
+++ b/src/ipbb/cmds/repo.py
@@ -288,10 +288,8 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
     # checkout out a revision should have been handled at the CLI
     # option handling stage.
     if revision is not None:
-        if dest is None:
-            dest = pathlib.Path(repo).stem
-        sh.git('init', dest, _out=sys.stdout, _cwd=ictx.srcdir)
-        sh.git('remote', 'add', repo, _out=sys.stdout, _cwd=ictx.srcdir)
+        sh.git('init', lRepoName, _out=sys.stdout, _cwd=ictx.srcdir)
+        sh.git('remote', 'add', 'origin', repo, _out=sys.stdout, _cwd=lRepoLocalPath)
         cprint('Fetching & checking out revision [blue]{}[/blue]'.format(revision))
         try:
             lFetchArgs = ['fetch', 'origin', revision, '-q']
@@ -300,7 +298,10 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
             sh.git(*lFetchArgs, _out=sys.stdout, _cwd=lRepoLocalPath)
             sh.git('checkout', revision, '-q', _out=sys.stdout, _cwd=lRepoLocalPath)
         except Exception as err:
-            click.ClickException("Failed to check out requested revision.")
+            if len(revision) < 40:
+                raise click.ClickException("Failed to check out requested revision. Please provide the full commit SHA (40 chars)")
+            else:
+                raise click.ClickException("Failed to check out requested revision.")
     else:
         lCloneArgs = ['clone', repo]
 

--- a/src/ipbb/cmds/repo.py
+++ b/src/ipbb/cmds/repo.py
@@ -300,12 +300,7 @@ def git(ictx, repo, branch_or_tag, revision, dest, depth):
             sh.git(*lFetchArgs, _out=sys.stdout, _cwd=lRepoLocalPath)
             sh.git('checkout', revision, '-q', _out=sys.stdout, _cwd=lRepoLocalPath)
         except Exception as err:
-            # NOTE: The assumption here is that the failed checkout
-            # did not alter the state of the cloned repo in any
-            # way. (This appears to be the case from experience but no
-            # hard reference could be found.)
-            cprint("Failed to check out requested revision." \
-                  " Staying on default branch.", style='red')
+            click.ClickException("Failed to check out requested revision.")
     else:
         lCloneArgs = ['clone', repo]
 


### PR DESCRIPTION
* Fix a bug introduced in #195 - the changes in that PR broke `ipbb add` if neither branch nor revision were specified (i.e. cloning the default branch).
* Also improve the cloning behaviour with the `-r` revision so that if the `--depth` flag is used then exactly the specified number of commits are downloaded (rather than up to twice that number).