### PR TITLE
Fail dependency parsing in case of undefined variables

### DIFF
--- a/src/ipbb/tools/alien.py
+++ b/src/ipbb/tools/alien.py
@@ -78,14 +78,7 @@ class AlienBranch(object):
         return str({ k: v for k, v in self.__dict__.items() if not k.startswith('_')})
 
     def __getattr__(self, name):
-        try:
-            return self.__dict__[name]
-        except KeyError:
-            if self._locked or name.startswith('__'):
-                raise
-            else:
-                value = self.__dict__[name] = type(self)()
-                return value
+        return self.__dict__[name]
 
     def __setattr__(self, name, value):
         if name not in self.__dict__ and name.startswith('_'):
@@ -105,7 +98,11 @@ class AlienBranch(object):
         if len(tokens) == 1:
             setattr(self, name, value)
         else:
-            setattr(self[tokens[0]], tokens[1], value)
+            try:
+                setattr(self[tokens[0]], tokens[1], value)
+            except KeyError:
+                self[tokens[0]] = type(self)()
+                setattr(self[tokens[0]], tokens[1], value)
 
     def __iter__(self):
         for b, o in self.__dict__.items():


### PR DESCRIPTION
In case an undefined variable is used in a dependency file, the current implementation of generate-project stumbles on, after showing a somewhat cryptic warning message.

This fix makes sure that parsing fails, and ipbb aborts with a clear message about parsing errors, showing the exact lines, as well as a message about which variable is undefined.

I discovered this, because I had a bug in my dependency files that led to an undefined variable being used in a conditional in a dependency file. IPBB's generate-project step produced a somewhat cryptic warning:
```
[13:04:28] WARNING: components/tcds2_link/firmware/cfg/tcds2_link_speed_select_10g.d3:4                                                                                                                                              _fileparser.py:312
           'tcds2_link_speed' is already defined with value '{}'. New value will not be applied ("10g").
```
and then stumbled on (with some missing dependencies, indeed).

This fix changes the behaviour into:
```
$ ipbb vivado generate-project
WARNING: dep parsing errors detected
ERROR: Project 'dth400_p1v1_tcds_nodeemu' contains 2 parsing errors.
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ dep file                                                                  ┃ line                                                                   ┃ error                                                            ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ cms-tcds2-firmware/components/tcds2_link/firmware/cfg/tcds2_link_pkg.d3:6 │ '? tcds2_link_speed == "5g" ? src tcds2_link_speed_choice_pkg_5g.vhd'  │ Parsing directive failed: name 'tcds2_link_speed' is not defined │
│ cms-tcds2-firmware/components/tcds2_link/firmware/cfg/tcds2_link_pkg.d3:7 │ '? tcds2_link_speed != "5g" ? src tcds2_link_speed_choice_pkg_10g.vhd' │ Parsing directive failed: name 'tcds2_link_speed' is not defined │
└───────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────┘
Aborted!
```