### PR TITLE
 Vivado: Add support for exporting XSA file 

### DIFF
--- a/doc/deptree.md
+++ b/doc/deptree.md
@@ -75,7 +75,8 @@ Describe the use of variables in relation to the script makers and as a way to s
 * `vivado.sim_top_entity` (`str`): Name of simulation top-entity in vivado
 * `vivado.binfile_options` (`str`): Bin file generation specific options
 * `vivado.mcsfile_options` (`str`): MCS file generation specific options
-* `vivado.svf_jtagchain_devices` (): 
+* `vivado.svf_jtagchain_devices` ():
+* `vivado.create_xsa` (`bool`): Create an XSA file
 
 ### VitisHLS
 


### PR DESCRIPTION
XSA file creation is enabled by adding the following to your depfile:
```
@vivado.create_xsa = True
```

Notably, the XSA-creating TCL command only works if there's a copy of the bitstream at `<implementation_run_directory>/<top_entity_name>.bit`. So I updated the `bitfile` function to save the bitfile there, and then copy it under the IPBB `products` directory immediately afterwards.