### PR TITLE
Make the handling of parser errors more robust

### DIFF
--- a/src/ipbb/depparser/_formatters.py
+++ b/src/ipbb/depparser/_formatters.py
@@ -45,7 +45,7 @@ class DepFormatter(object):
 
     def draw_depfile_tree(self) -> Tree:
         if not self.parser.depfile:
-            return "[red]Top depfile not found[/red]"
+            return "[red]Top depfile not found (or not parsed successfully)[/red]"
 
         attrs = Table(box=None, show_header=False)
         attrs.add_column('pkg', style='cyan', justify="right", no_wrap=True)


### PR DESCRIPTION
When the parser encounters (rather serious) problems, it tends to bail with a slightly misleading message stating that the top-level dependency file cannot be found. These modifications improve the error handling, show more details about the error(s) encountered, and improve on that misleading message.

To see the effect, simply try a dependency file containing the following line.

```
? True ? @tmp = "X"
```