### PR TITLE
Improve the order of processing during dependency file parsing

### DIFF
--- a/src/ipbb/depparser/_fileparser.py
+++ b/src/ipbb/depparser/_fileparser.py
@@ -489,11 +489,6 @@ class DepFileParser(object):
                     if not lLine:
                         continue
 
-                    # Process variable assignment directives
-                    lLine = self._line_process_assignments(lLine, lDepInfo)
-                    if not lLine:
-                        continue
-
                     # Process conditional directives
                     lLine = self._line_process_conditional(lLine, lDepInfo)
                     if not lLine:
@@ -501,6 +496,11 @@ class DepFileParser(object):
 
                     # Replace variables
                     lLine = self._line_replace_vars(lLine, lDepInfo)
+
+                    # Process variable assignment directives
+                    lLine = self._line_process_assignments(lLine, lDepInfo)
+                    if not lLine:
+                        continue
 
                 except DepLineError as lExc:
                     lCurrentFile.errors.append((aPackage, aComponent, aDepFileName, lDepFilePath, lLineNr, lLine, lExc))


### PR DESCRIPTION
The updated order allows tricks like conditional declaration of variables. Nice!

Things like the following are now possible. Whether one wants to do this kind of thing, can be debated, of course.

```
? setting == "value" ? @tmp = "ABC"
```