### PR TITLE
Avoid 'cropping' of contents of wide dependency tables

### DIFF
--- a/src/ipbb/cmds/dep.py
+++ b/src/ipbb/cmds/dep.py
@@ -119,7 +119,13 @@ def report(ictx, pager, filters):
 
             if not lParser.commands[k]:
                 continue
-            lCmdTable = Table(*(lCmdHeaders + (['lib'] if k == 'src' else [])), title=f'{k} ({len(lParser.commands[k])})', title_style='blue', title_justify='left', expand=True)
+            lColumnHeaders = (lCmdHeaders + (['lib'] if k == 'src' else []))
+            lColumns = (Column(header=i, overflow='fold') for i in lColumnHeaders)
+            lCmdTable = Table(*lColumns,
+                              title=f'{k} ({len(lParser.commands[k])})',
+                              title_style='blue',
+                              title_justify='left',
+                              expand=True)
             for lCmd in lParser.commands[k]:
                 lRow = [
                     relpath(lCmd.filepath, ictx.srcdir),


### PR DESCRIPTION
The current behaviour is to 'crop' strings in rows that would exceed the terminal width and append ellipsis. This looks nice, and may be very grep-friendly, but it removes some interesting information. As in: it tends to remove the tail ends of long path/file names. This change makes these occurrences 'fold over' to the next line instead. Not as pretty, but it retains all information.