### PR TITLE
Add support for top-level generic settings in Vivado simulation

### DIFF
--- a/src/ipbb/cli/vivado.py
+++ b/src/ipbb/cli/vivado.py
@@ -77,6 +77,7 @@ def checksyntax(ictx, *args, **kwargs):
 
 # ------------------------------------------------------------------------------
 @vivado.command('simulate', short_help='Run behavioral simulation on the current project.')
+@click.option('--generic-top', 'aGenericTop', default="", help="Specify values for top-level generics, using the xelab -generic_top syntax.")
 @click.pass_obj
 @click.pass_context
 def checksyntax(ctx, *args, **kwargs):

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -240,7 +240,7 @@ def checksyntax(ictx):
     )
 
 # ------------------------------------------------------------------------------
-def runsimulation(ictx):
+def runsimulation(ictx, aGenericTop):
 
     lSessionId = 'run-sim'
 
@@ -262,6 +262,7 @@ def runsimulation(ictx):
 
             # Execute the behavioral simulation
             lConsole('set_property target_simulator "XSim" [current_project]')
+            lConsole(f"set_property generic {{{aGenericTop}}} [get_filesets sim_1]")
             sim_output = lConsole('launch_simulation -mode "behavioral"', aMaxLen=None)
 
     except VivadoConsoleError as lExc:


### PR DESCRIPTION
This adds a '--generic-top' option to the 'ipbb vivado simulate' command that supports the same syntax as the xelab -generic_top option. It allows manipulation of top-level generics from the command line for simulation runs.