### PR TITLE
Make sure that 'ipbb vivado package' always produces the package in the same location

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -20,6 +20,7 @@ from rich.table import Table
 
 from .schema import project_schema, validate_schema
 from .dep import hash
+from .proj import cd
 
 from ..console import cprint, console
 from ..utils import which, SmartOpen, mkdir
@@ -922,6 +923,11 @@ def package(ictx, aTag):
     lDebugProbesPath = lBaseName + '.ltx'
     if not os.path.exists(lDebugProbesPath):
         lDebugProbesPath = None
+
+    # Change directory to the project directory, to ensure that even
+    # when 'ipbb vivado package' is called from elsewhere, the
+    # products end up in the usual place.
+    cd(ictx, ictx.currentproj.name, False)
 
     lPkgPath = 'package'
     lPkgSrcPath = join(lPkgPath, 'src')


### PR DESCRIPTION
At the moment, the 'vivado package' command generates the package in the current directory. So when one executes this command from outside the project directory, the package directory is created outside the project directory too.

Assuming this is _not_ an explicit design choice, this modification ensures that the package is always created in the project directory.