### PR TITLE
Support Vivado slack histograms

### DIFF
--- a/src/ipbb/cli/vivado.py
+++ b/src/ipbb/cli/vivado.py
@@ -126,6 +126,22 @@ def resource_usage(ictx, *args, **kwargs):
 
 
 # ------------------------------------------------------------------------------
+@vivado.command('slack-histogram', short_help="Slack histogram")
+@click.option('-c', '--cell', 'aCell', default=None, help="Submodule name")
+@click.option('-f', '--file', 'aFile', type=click.Path(), default=None, help="Output file")
+@click.option('--details', 'aDetails', is_flag=True, default=False, help="Provide path-by-path slack detail")
+@click.option('--num-bins', 'aNumBins', type=int, default=None, help="Number of bins")
+@click.option('--slack-less-than', 'aSlackMax', type=float, default=None, help="Slack upper limit (ns)")
+@click.option('--slack-greater-than', 'aSlackMin', type=float, default=None, help="Slack lower limit (ns)")
+@click.pass_obj
+@click.pass_context
+def resource_usage(ictx, *args, **kwargs):
+    '''Create a slack histogram'''
+    from ..cmds.vivado import slack_histogram
+    return (ictx.command.name, slack_histogram, args, kwargs)
+
+
+# ------------------------------------------------------------------------------
 @vivado.command('bitfile', short_help="Generate the bitfile.")
 @click.pass_obj
 @click.pass_context

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -443,18 +443,17 @@ def impl(ictx, aNumJobs, aStopOnTimingErr):
 
 
 # ------------------------------------------------------------------------------
-
 def resource_usage(ictx, aCell, aDepth, aFile, aSLR):
 
     lSessionId = 'usage'
 
-    # Check that the project exists 
+    # Check that the project exists.
     ensure_vivado_project_path(ictx.vivadoProjFile)
 
     # And that the Vivado ictx is up
     ensure_vivado(ictx)
 
-    lCmd = 'report_utilization '
+    lCmd = 'report_utilization'
     if aSLR:
         lCmd += ' -slr '
     else:
@@ -465,6 +464,49 @@ def resource_usage(ictx, aCell, aDepth, aFile, aSLR):
     if aFile:
         lCmd += ' -file ' + aFile
 
+    try:
+        with ictx.vivadoSessions.getctx(lSessionId) as lConsole:
+            lProject = VivadoProject(lConsole, ictx.vivadoProjFile)
+            for c in (
+                    'open_run impl_1',
+                    lCmd
+                ):
+                lConsole(c)
+    except VivadoConsoleError as lExc:
+        logVivadoConsoleError(lExc)
+        raise click.Abort()
+
+
+# ------------------------------------------------------------------------------
+def slack_histogram(ictx, aCell, aFile, aDetails, aNumBins, aSlackMax, aSlackMin):
+
+    lSessionId = 'slack'
+
+    # Check that the project exists.
+    ensure_vivado_project_path(ictx.vivadoProjFile)
+
+    # And that the Vivado ictx is up
+    ensure_vivado(ictx)
+
+    lCmd = "create_slack_histogram"
+    lCmd += " -significant_digits 3"
+    if aCell:
+        lCmd += f" -cells {aCell}"
+
+    if aFile:
+        lCmd += f" -file {aFile}"
+
+    if aDetails:
+        lCmd += " -details"
+
+    if aNumBins:
+        lCmd += f" -num_bins {aNumBins}"
+
+    if aSlackMax:
+        lCmd += f" -slack_less_than {aSlackMax}"
+
+    if aSlackMin:
+        lCmd += f" -slack_greater_than {aSlackMin}"
 
     try:
         with ictx.vivadoSessions.getctx(lSessionId) as lConsole:


### PR DESCRIPTION
Support 'ipbb vivado slack-histogram' as a wrapper around the create_slack_histogram command, similar to the way 'ipbb vivado resource-usage' wraps the report_utilization command.