### PR TITLE
Add depfile variables to Vivado package (.tgz)

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -1004,6 +1004,7 @@ def package(ictx, aTag):
             'build host': socket.gethostname().replace('.', '_'),
             'time': time.strftime("%a, %d %b %Y %H:%M:%S +0000"),
             'md5': lHash.hexdigest(),
+            'variables': dict(lDepFileParser.settings),
         }
     )
 


### PR DESCRIPTION
This branch adds the values of depfile variables to the `.tgz` package produced by `ipbb vivado package`.

This allows software to e.g. check the board that FW was built for before loading the FW (to prevent users from accidentally loading FW intended for another board).