### PR TITLE
Add new dep subcommand for printing out the values of user-specified depfile variables

### DIFF
--- a/src/ipbb/cli/dep.py
+++ b/src/ipbb/cli/dep.py
@@ -29,6 +29,16 @@ def report(ictx, pager, filters):
 
 
 # ------------------------------------------------------------------------------
+@dep.command('print-variables')
+@click.pass_obj
+@click.argument('format_string')
+def print_variables(ictx, format_string):
+    '''Print depfile variables of current project, according to the supplied format string'''
+    from ..cmds.dep import print_variables
+    print_variables(ictx, format_string)
+
+
+# ------------------------------------------------------------------------------
 @dep.command('ls', short_help="List project files by group")
 @click.argument('group', type=click.Choice(dep_command_types))
 @click.option('-o', '--output', default=None, help="Destination of the command output. Default: stdout")

--- a/src/ipbb/cmds/dep.py
+++ b/src/ipbb/cmds/dep.py
@@ -158,6 +158,12 @@ def report(ictx, pager, filters):
             raise SystemExit(1)
 
 
+# ------------------------------------------------------------------------------
+
+def print_variables(ictx, format_string):
+    lVariables = dict(ictx.depParser.settings)
+    print(format_string.format(**lVariables))
+
 
 # ------------------------------------------------------------------------------
 

--- a/src/ipbb/cmds/proj.py
+++ b/src/ipbb/cmds/proj.py
@@ -176,7 +176,7 @@ def cd(ictx, projname, aVerbose):
     ictx._autodetect()
 
     # cprint(f"New current directory {os.getcwd()}")
-    if ictx.currentproj:
+    if ictx.currentproj and aVerbose:
         cprint(f"Current project: [cyan]{ictx.currentproj.name}[/cyan]")
 
 


### PR DESCRIPTION
New command: `ipbb dep print-variables FORMAT_STRING`

Useful in particular if one needs to extract IPBB depfile variables for use in another script (e.g. to simpify the generation of TCDS2 XCI files in EMP projects).