### PR TITLE
Implement support for Vivado Clock Domain Crossing reports

### DIFF
--- a/src/ipbb/cli/vivado.py
+++ b/src/ipbb/cli/vivado.py
@@ -146,7 +146,7 @@ def resource_usage(ictx, *args, **kwargs):
 @click.option('-c', '--cell', 'aCell', default=None, help="Submodule name")
 @click.option('-f', '--file', 'aFile', type=click.Path(), default=None, help="Output file")
 @click.option('--details', 'aDetails', is_flag=True, default=False, help="Provide details of paths not safely timed")
-@click.option('--severity', 'aSeverity', type=click.Choice(['Info', 'Warning', 'Critical']), default=None, help="Report only the severity specified")
+@click.option('--severity', 'aSeverity', type=click.Choice(['info', 'warning', 'critical']), default=None, help="Report only the severity specified")
 @click.pass_obj
 @click.pass_context
 def resource_usage(ictx, *args, **kwargs):

--- a/src/ipbb/cli/vivado.py
+++ b/src/ipbb/cli/vivado.py
@@ -142,6 +142,20 @@ def resource_usage(ictx, *args, **kwargs):
 
 
 # ------------------------------------------------------------------------------
+@vivado.command('cdc-report', short_help="Create a CDC report")
+@click.option('-c', '--cell', 'aCell', default=None, help="Submodule name")
+@click.option('-f', '--file', 'aFile', type=click.Path(), default=None, help="Output file")
+@click.option('--details', 'aDetails', is_flag=True, default=False, help="Provide details of paths not safely timed")
+@click.option('--severity', 'aSeverity', type=click.Choice(['Info', 'Warning', 'Critical']), default=None, help="Report only the severity specified")
+@click.pass_obj
+@click.pass_context
+def resource_usage(ictx, *args, **kwargs):
+    '''Create a CDC report'''
+    from ..cmds.vivado import cdc_report
+    return (ictx.command.name, cdc_report, args, kwargs)
+
+
+# ------------------------------------------------------------------------------
 @vivado.command('bitfile', short_help="Generate the bitfile.")
 @click.pass_obj
 @click.pass_context

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -521,6 +521,43 @@ def slack_histogram(ictx, aCell, aFile, aDetails, aNumBins, aSlackMax, aSlackMin
 
 
 # ------------------------------------------------------------------------------
+def cdc_report(ictx, aCell, aFile, aDetails, aSeverity):
+
+    lSessionId = 'cdc_report'
+
+    # Check that the project exists.
+    ensure_vivado_project_path(ictx.vivadoProjFile)
+
+    # And that the Vivado ictx is up
+    ensure_vivado(ictx)
+
+    lCmd = "report_cdc"
+    if aCell:
+        lCmd += f" -cells {aCell}"
+
+    if aFile:
+        lCmd += f" -file {aFile}"
+
+    if aDetails:
+        lCmd += " -details"
+
+    if aSeverity:
+        lCmd += f" -severity {aSeverity}"
+
+    try:
+        with ictx.vivadoSessions.getctx(lSessionId) as lConsole:
+            lProject = VivadoProject(lConsole, ictx.vivadoProjFile)
+            for c in (
+                    'open_run impl_1',
+                    lCmd
+                ):
+                lConsole(c)
+    except VivadoConsoleError as lExc:
+        logVivadoConsoleError(lExc)
+        raise click.Abort()
+
+
+# ------------------------------------------------------------------------------
 def bitfile(ictx):
     '''Create a bitfile'''
 


### PR DESCRIPTION
Just adding to the list of supported Vivado reports. This time: add basic support for the report_cdc command.