### PR TITLE
Fix detection of errors in Vivado simulation

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -273,6 +273,14 @@ def runsimulation(ictx, aGenericTop):
     # part of the Vivado project, and this is not what we want.
     lConsole('set_property generic {} [get_filesets sim_1]')
 
+    # Now dig through the simulation log for errors.
+    sim_errors = [i for i in sim_output if (i.lower().find("error") > -1)]
+    sim_error_detected = len(sim_errors) > 0
+    if sim_error_detected:
+        error_strings = ["  {0:s}".format(i) for i in sim_errors]
+        logVivadoSimulationError(error_strings)
+        raise click.Abort()
+
     # Now dig through the simulation log for failures.
     # This assumes that simulation issues are reported using the VHDL
     # 'report "XXX" severity failure'.


### PR DESCRIPTION
The 'vivado simulate' command so far only checks for failures reported by the simulation (i.e., assertion failures). With this change, it also checks for Vivado simulation errors (e.g., XPM_MEMORY 40-36 and friends).