### PR TITLE
Remove vunit-hdl from dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ PyYAML==6.0
 rich==12.2.0
 sh==1.14.2
 vsg==3.10.0
-vunit-hdl==4.6.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ install_requires += [
         "rich==12.6.0",
         "sh==1.14.2",
         # "vsg==3.10.0",
-        "vunit-hdl==4.6.0",
     ]
 
 setup(


### PR DESCRIPTION
This is a) not needed/used, and b) really messes up the CI4FPGA environments.