### PR TITLE
Fix vivado sim error detection

### DIFF
--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -276,8 +276,7 @@ def runsimulation(ictx, aGenericTop):
     # Now dig through the simulation log for errors.
     def sounds_like_sim_error(line):
         tmp = line.strip().lower()
-        res = (tmp.find("error") > -1) and \
-            not tmp.startswith("warn")
+        res = tmp.startswith("error")
         return res
     sim_errors = [i for i in sim_output if sounds_like_sim_error(i)]
     sim_error_detected = len(sim_errors) > 0

--- a/src/ipbb/cmds/vivado.py
+++ b/src/ipbb/cmds/vivado.py
@@ -274,7 +274,12 @@ def runsimulation(ictx, aGenericTop):
     lConsole('set_property generic {} [get_filesets sim_1]')
 
     # Now dig through the simulation log for errors.
-    sim_errors = [i for i in sim_output if (i.lower().find("error") > -1)]
+    def sounds_like_sim_error(line):
+        tmp = line.strip().lower()
+        res = (tmp.find("error") > -1) and \
+            not tmp.startswith("warn")
+        return res
+    sim_errors = [i for i in sim_output if sounds_like_sim_error(i)]
     sim_error_detected = len(sim_errors) > 0
     if sim_error_detected:
         error_strings = ["  {0:s}".format(i) for i in sim_errors]


### PR DESCRIPTION
It turns out that it is not all that straightforward to detect simulation errors without triggering false positives.

- The testbench output can of course contain strings like 'checking for errors'.
- The Vivado output seems to be inconsistent in terms of capitalisation; both 'Error' and 'ERROR' are present.
- We want to catch XSIM errors, and also XPM_MEMORY etc. errors.

Simply looking for 'error' is too tight. There are cases (e.g., XSIM 43-3431) that are warnings and contain strings like 'If errors occur'.

Current approach: look for occurrences of 'error' in lines that do not start with 'warn'.